### PR TITLE
Add RL support via Stable-Baselines3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,3 +184,5 @@ logs/
 reports/
 models/*.pkl
 results/run_*.csv
+agents/*.zip
+agents/best_model.txt

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ bot-trade/
 ├── config.yaml # Configurations for coin, thresholds, etc.
 ├── market_data.py # Binance data fetcher (via ccxt)
 ├── ml_strategy.py # ML-based strategy with auto-fallback
+├── env_trading.py # Gym environment for RL
+├── train_rl.py # Train PPO/DQN agent
+├── run_rl_agent.py # Run trained RL agent
 ├── results_logger.py # Logs trades and feeds training dataset
 ├── training_dataset.csv # Cumulative dataset for ML training
 ├── requirements.txt # Dependencies
@@ -30,6 +33,7 @@ Edit
 ## 🧠 Strategy
 
 - **ML strategy** using `DecisionTreeClassifier`
+- **RL strategy** using `Stable-Baselines3` (PPO)
 - Strategy input features: `price_change`, `coin_delta`, `usdt_delta`, `value_delta`, etc.
 - Auto retrain after configurable trade threshold
 - Feature mismatch recovery included
@@ -54,6 +58,7 @@ coins:
   - SOL/USDT
 max_trades_before_retrain: 100
 strategy: "ml"  # or "rule"
+# set to "rl" to use the reinforcement learning agent
 debug_mode: true
 report_format: "pdf"
 output_dirs:

--- a/config.yaml
+++ b/config.yaml
@@ -6,7 +6,7 @@ coins:
   - C/USDT
 
 max_trades_before_retrain: 100
-strategy: "ml"  # or "rule"
+strategy: "ml"  # or "rule" or "rl"
 debug_mode: true
 report_format: "pdf"
 default_coin: "C/USDT"

--- a/dashboard.py
+++ b/dashboard.py
@@ -26,6 +26,27 @@ class Dashboard(cmd.Cmd):
         for f in sorted(os.listdir('models')):
             print(f)
 
+    def do_train_rl(self, arg):
+        subprocess.run(['python', 'train_rl.py'])
+
+    def do_run_rl(self, arg):
+        subprocess.run(['python', 'run_rl_agent.py'])
+
+    def do_eval_rl(self, arg):
+        subprocess.run(['python', 'evaluate_model.py'])
+
+    def do_switch_strategy(self, arg):
+        if arg not in ['ml', 'rule', 'rl']:
+            print('Usage: switch_strategy [ml|rule|rl]')
+            return
+        import yaml
+        with open('config.yaml', 'r') as f:
+            cfg = yaml.safe_load(f)
+        cfg['strategy'] = arg
+        with open('config.yaml', 'w') as f:
+            yaml.dump(cfg, f)
+        print(f'Strategy switched to {arg}')
+
     def do_edit_file(self, arg):
         if not arg:
             print('Usage: edit_file <path>')

--- a/env_trading.py
+++ b/env_trading.py
@@ -1,0 +1,73 @@
+import numpy as np
+import pandas as pd
+from gymnasium import Env, spaces
+from typing import List, Tuple
+
+from strategy_features import add_strategy_features
+
+class TradingEnv(Env):
+    """Simple trading environment for RL based on historical OHLCV data."""
+
+    def __init__(self, data: pd.DataFrame, initial_balance: float = 1000.0):
+        super().__init__()
+        self.original_df = data.copy().reset_index(drop=True)
+        self.df = add_strategy_features(self.original_df)
+        self.initial_balance = initial_balance
+
+        self.action_space = spaces.Discrete(3)  # HOLD, BUY, SELL
+        # observation: indicators + price change + position state
+        sample_obs = self._make_obs(0, 0.0, 0.0)
+        self.observation_space = spaces.Box(
+            low=-np.inf,
+            high=np.inf,
+            shape=(len(sample_obs),),
+            dtype=np.float32,
+        )
+
+        self.reset()
+
+    def _make_obs(self, idx: int, usdt: float, coin: float) -> np.ndarray:
+        row = self.df.iloc[idx]
+        obs = [
+            row.get("price", row.get("close", 0.0)),
+            row.get("price_change", 0.0),
+            row.get("rsi_14", 0.0),
+            row.get("macd", 0.0),
+            row.get("macd_signal", 0.0),
+            row.get("macd_hist", 0.0),
+            row.get("bollinger_upper_diff", 0.0),
+            row.get("bollinger_lower_diff", 0.0),
+            usdt / self.initial_balance,
+            (coin * row.get("price", row.get("close", 0.0))) / self.initial_balance,
+        ]
+        return np.array(obs, dtype=np.float32)
+
+    def reset(self, seed: int | None = None, options: dict | None = None):
+        super().reset(seed=seed)
+        self.index = 0
+        self.usdt = self.initial_balance
+        self.coin = 0.0
+        self.prev_value = self.initial_balance
+        return self._make_obs(self.index, self.usdt, self.coin), {}
+
+    def step(self, action: int):
+        done = False
+        price = self.df.iloc[self.index].get("price", self.df.iloc[self.index].get("close", 0.0))
+        if action == 1 and self.usdt > 0:  # BUY
+            amount = self.usdt / price
+            self.coin += amount
+            self.usdt = 0.0
+        elif action == 2 and self.coin > 0:  # SELL
+            self.usdt += self.coin * price
+            self.coin = 0.0
+        self.index += 1
+        if self.index >= len(self.df) - 1:
+            done = True
+        new_price = self.df.iloc[self.index].get("price", self.df.iloc[self.index].get("close", 0.0))
+        total_value = self.usdt + self.coin * new_price
+        reward = total_value - self.prev_value
+        self.prev_value = total_value
+        obs = self._make_obs(self.index, self.usdt, self.coin)
+        info = {"total_value": total_value, "timestamp": self.df.iloc[self.index]["timestamp"]}
+        return obs, float(reward), done, False, info
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,7 @@ joblib
 fpdf
 pyyaml
 ccxt
+stable-baselines3
+gymnasium
+torch
+ta

--- a/run_bot.py
+++ b/run_bot.py
@@ -74,7 +74,12 @@ def main():
     print('🚀 Running trading bot')
     print('='*60)
     try:
-        script = 'bot_loop_ml.py' if STRATEGY == 'ml' else 'bot_loop.py'
+        if STRATEGY == 'ml':
+            script = 'bot_loop_ml.py'
+        elif STRATEGY == 'rl':
+            script = 'run_rl_agent.py'
+        else:
+            script = 'bot_loop.py'
         run_step('Running trading logic', ['python', script])
         maybe_retrain()
     except Exception as e:

--- a/run_rl_agent.py
+++ b/run_rl_agent.py
@@ -1,0 +1,72 @@
+import os
+import json
+import pandas as pd
+from stable_baselines3 import PPO
+
+from env_trading import TradingEnv
+from market_data import fetch_ohlcv
+from results_logger import simulate_wallet
+
+AGENT_DIR = "agents"
+
+
+def load_best_model():
+    path_file = os.path.join(AGENT_DIR, "best_model.txt")
+    if os.path.exists(path_file):
+        with open(path_file, "r") as f:
+            path = f.read().strip()
+        if os.path.exists(path):
+            return path
+    raise FileNotFoundError("Best model not found. Train the RL agent first.")
+
+
+def main(model_path: str | None = None):
+    if model_path is None:
+        model_path = load_best_model()
+
+    model = PPO.load(model_path)
+    df = fetch_ohlcv()
+    df.rename(columns={"close": "price"}, inplace=True)
+    df["volume"] = 1.0
+    env = TradingEnv(df)
+
+    obs, _ = env.reset()
+    actions = []
+    done = False
+    while not done:
+        action, _ = model.predict(obs, deterministic=True)
+        obs, reward, done, _, info = env.step(int(action))
+        ts = info.get("timestamp")
+        price = info.get("price", df.iloc[env.index]["price"] if env.index < len(df) else df.iloc[-1]["price"])
+        signal = {0: "HOLD", 1: "BUY", 2: "SELL"}[int(action)]
+        actions.append((ts, price, signal))
+
+    logs, final_val = simulate_wallet(actions)
+    print(f"Final portfolio value: {final_val:.2f} USDT")
+
+    # update memory
+    mem_path = os.path.join('memory', 'memory.json')
+    memory = {}
+    if os.path.exists(mem_path):
+        try:
+            with open(mem_path, 'r') as f:
+                memory = json.load(f)
+        except Exception:
+            memory = {}
+    memory['last_rl_reward'] = final_val - env.initial_balance
+    memory['last_rl_total_value'] = final_val
+    memory['rl_policy'] = os.path.basename(model_path)
+    os.makedirs('memory', exist_ok=True)
+    with open(mem_path, 'w') as f:
+        json.dump(memory, f, indent=2)
+
+    # Append new run to dataset for continual learning
+    dataset = os.path.join(os.path.dirname(__file__), "training_dataset.csv")
+    res_df = pd.DataFrame(actions, columns=["timestamp", "price", "signal"])
+    res_df.to_csv(dataset, mode="a", index=False, header=False)
+
+
+if __name__ == "__main__":
+    import sys
+    path = sys.argv[1] if len(sys.argv) > 1 else None
+    main(path)

--- a/strategy_features.py
+++ b/strategy_features.py
@@ -2,9 +2,14 @@ import pandas as pd
 import ta
 
 def add_strategy_features(df: pd.DataFrame) -> pd.DataFrame:
-    # Ensure necessary columns exist
-    if 'close' not in df or 'volume' not in df:
-        raise ValueError("DataFrame must contain 'close' and 'volume' columns")
+    """Add common trading indicators used by various strategies."""
+    if 'close' not in df:
+        if 'price' in df:
+            df = df.rename(columns={'price': 'close'})
+        else:
+            raise ValueError("DataFrame must contain 'close' column")
+    if 'volume' not in df:
+        df['volume'] = 1.0
 
     df = df.copy()
 

--- a/train_rl.py
+++ b/train_rl.py
@@ -1,0 +1,53 @@
+import os
+import json
+from datetime import datetime
+import pandas as pd
+from stable_baselines3 import PPO
+from stable_baselines3.common.vec_env import DummyVecEnv
+
+from env_trading import TradingEnv
+
+DATA_PATH = "training_dataset.csv"
+AGENT_DIR = "agents"
+os.makedirs(AGENT_DIR, exist_ok=True)
+
+
+def load_data(path: str) -> pd.DataFrame:
+    df = pd.read_csv(path)
+    if "timestamp" in df.columns:
+        df["timestamp"] = pd.to_datetime(df["timestamp"])
+    df.rename(columns={"price": "close"}, inplace=True)
+    df["volume"] = 1.0
+    return df
+
+
+def main():
+    df = load_data(DATA_PATH)
+    env = DummyVecEnv([lambda: TradingEnv(df)])
+
+    model = PPO("MlpPolicy", env, verbose=1)
+    model.learn(total_timesteps=10000)
+
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    model_path = os.path.join(AGENT_DIR, f"ppo_{ts}.zip")
+    model.save(model_path)
+    with open(os.path.join(AGENT_DIR, "best_model.txt"), "w") as f:
+        f.write(model_path)
+    print(f"Model saved to {model_path}")
+
+    mem_path = os.path.join('memory', 'memory.json')
+    memory = {}
+    if os.path.exists(mem_path):
+        try:
+            with open(mem_path, 'r') as m:
+                memory = json.load(m)
+        except Exception:
+            memory = {}
+    memory['rl_policy'] = os.path.basename(model_path)
+    os.makedirs('memory', exist_ok=True)
+    with open(mem_path, 'w') as m:
+        json.dump(memory, m, indent=2)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add Gym trading environment `env_trading.py`
- add PPO training script `train_rl.py`
- add RL inference runner `run_rl_agent.py`
- update `run_bot.py` and `dashboard.py` to support RL strategy
- update configs and README
- include RL packages in requirements
- store RL results in `memory.json`
- ignore generated agent files

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -q -r requirements.txt` *(fails: Operation cancelled by user)*

------
https://chatgpt.com/codex/tasks/task_b_6883e0d3e9288324b64f8e528e6febee