### PR TITLE
Fix duplicate import and empty actions check

### DIFF
--- a/results_logger.py
+++ b/results_logger.py
@@ -2,7 +2,6 @@ import pandas as pd
 import os
 import json
 from datetime import datetime
-import os
 
 # Ensure required directories exist
 for d in ["models", "results", "reports", "logs"]:
@@ -19,6 +18,9 @@ def simulate_wallet(actions, initial_usdt=None, fee=0.001):
     else:
         initial_usdt = 1000.0
         state = {}
+
+    if not actions:
+        raise ValueError("No actions were logged to simulate wallet.")
 
     usdt = initial_usdt
     coin = 0.0


### PR DESCRIPTION
## Summary
- remove redundant `import os` in `results_logger.py`
- raise a clear error when no actions are supplied to `simulate_wallet`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_6884101ce89483249be3804dcf31e108