### PR TITLE
Implement dashboard roadmap commands

### DIFF
--- a/evaluate_model_metrics.py
+++ b/evaluate_model_metrics.py
@@ -1,0 +1,31 @@
+import pandas as pd
+import joblib
+from sklearn.model_selection import train_test_split
+from sklearn.metrics import accuracy_score, precision_score, recall_score, f1_score
+import os
+
+
+def main():
+    df = pd.read_csv('training_dataset.csv')
+    X = df.drop(columns=['pnl_class']).select_dtypes(include=['number'])
+    y = df['pnl_class']
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.2, random_state=42
+    )
+    model = joblib.load(os.path.join('models', 'trained_model.pkl'))
+    y_pred = model.predict(X_test)
+
+    print(f"Accuracy: {accuracy_score(y_test, y_pred):.4f}")
+    print(
+        f"Precision: {precision_score(y_test, y_pred, average='weighted', zero_division=0):.4f}"
+    )
+    print(
+        f"Recall: {recall_score(y_test, y_pred, average='weighted', zero_division=0):.4f}"
+    )
+    print(
+        f"F1 Score: {f1_score(y_test, y_pred, average='weighted', zero_division=0):.4f}"
+    )
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add new `evaluate_model_metrics.py` for extended evaluation metrics
- overhaul `dashboard.py` commands based on roadmap
  - implement `train`, `train_rl`, `run_rl`, `eval`, `eval_full`
  - implement `reset` to wipe working directories
  - implement `stats` showing best model, last PnL and F1 history
- remove old dashboard commands

## Testing
- `python -m py_compile dashboard.py evaluate_model_metrics.py`
- `python dashboard.py -c 'help'`

------
https://chatgpt.com/codex/tasks/task_b_6884101189448324b0b2e64ce5cb4e9b