### PR TITLE
Improve PPO training loop with early stopping

### DIFF
--- a/train_rl.py
+++ b/train_rl.py
@@ -9,6 +9,8 @@ from env_trading import TradingEnv
 
 DATA_PATH = "training_dataset.csv"
 AGENT_DIR = "agents"
+EPISODES = 50
+PATIENCE = 5
 os.makedirs(AGENT_DIR, exist_ok=True)
 
 
@@ -21,19 +23,57 @@ def load_data(path: str) -> pd.DataFrame:
     return df
 
 
+def evaluate(model: PPO, df: pd.DataFrame) -> float:
+    """Run the model on the given dataframe and return the total reward."""
+    env = TradingEnv(df)
+    obs, _ = env.reset()
+    done = False
+    info = {}
+    while not done:
+        action, _ = model.predict(obs, deterministic=True)
+        obs, reward, done, _, info = env.step(int(action))
+    final_value = info.get("total_value", env.prev_value)
+    return final_value - env.initial_balance
+
+
 def main():
     df = load_data(DATA_PATH)
-    env = DummyVecEnv([lambda: TradingEnv(df)])
+    train_env = DummyVecEnv([lambda: TradingEnv(df)])
+    eval_df = df.copy()
 
-    model = PPO("MlpPolicy", env, verbose=1)
-    model.learn(total_timesteps=10000)
+    model = PPO("MlpPolicy", train_env, verbose=1)
 
-    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
-    model_path = os.path.join(AGENT_DIR, f"ppo_{ts}.zip")
-    model.save(model_path)
-    with open(os.path.join(AGENT_DIR, "best_model.txt"), "w") as f:
-        f.write(model_path)
-    print(f"Model saved to {model_path}")
+    best_reward = -float("inf")
+    best_path_file = os.path.join(AGENT_DIR, "best_model.txt")
+    if os.path.exists(best_path_file):
+        try:
+            with open(best_path_file, "r") as f:
+                prev_path = f.read().strip()
+            if os.path.exists(prev_path):
+                prev_model = PPO.load(prev_path)
+                best_reward = evaluate(prev_model, eval_df)
+        except Exception:
+            best_reward = -float("inf")
+
+    no_improve = 0
+    for ep in range(1, EPISODES + 1):
+        model.learn(total_timesteps=len(df) - 1, reset_num_timesteps=False)
+        reward = evaluate(model, eval_df)
+        if reward > best_reward:
+            best_reward = reward
+            ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+            model_path = os.path.join(AGENT_DIR, f"ppo_{ts}.zip")
+            model.save(model_path)
+            with open(best_path_file, "w") as f:
+                f.write(model_path)
+            print(f"Episode {ep}: reward {reward:.2f} -> new best model saved")
+            no_improve = 0
+        else:
+            no_improve += 1
+            print(f"Episode {ep}: reward {reward:.2f} (no improvement)")
+            if no_improve >= PATIENCE:
+                print(f"No improvement for {PATIENCE} episodes, stopping early")
+                break
 
     mem_path = os.path.join('memory', 'memory.json')
     memory = {}
@@ -43,7 +83,10 @@ def main():
                 memory = json.load(m)
         except Exception:
             memory = {}
-    memory['rl_policy'] = os.path.basename(model_path)
+    if os.path.exists(best_path_file):
+        with open(best_path_file, 'r') as f:
+            memory['rl_policy'] = os.path.basename(f.read().strip())
+    memory['last_rl_reward'] = best_reward
     os.makedirs('memory', exist_ok=True)
     with open(mem_path, 'w') as m:
         json.dump(memory, m, indent=2)


### PR DESCRIPTION
## Summary
- loop over multiple episodes when training PPO
- evaluate reward each episode and save new best model with timestamp
- stop training early if no improvement is seen for several episodes

## Testing
- `python -m py_compile train_rl.py`

------
https://chatgpt.com/codex/tasks/task_b_6884100454308324acb8fe53d647bca6