### PR TITLE
Add RL metrics

### DIFF
--- a/evaluate_model.py
+++ b/evaluate_model.py
@@ -2,6 +2,7 @@ import os
 from datetime import datetime
 import pandas as pd
 import joblib
+import json
 from sklearn.model_selection import train_test_split
 from sklearn.metrics import accuracy_score, f1_score, classification_report, confusion_matrix
 import numpy as np
@@ -49,11 +50,23 @@ def evaluate():
     roll_max = cumulative.cummax()
     drawdown = (cumulative - roll_max) / roll_max
     max_drawdown = drawdown.min()
+    # rolling drawdown over 30 periods
+    rolling_max = cumulative.rolling(window=30, min_periods=1).max()
+    rolling_drawdown = ((cumulative - rolling_max) / rolling_max).min()
     win_rate = (test_df['returns'] > 0).mean()
+    # compute pnl for daily average
+    if 'total_value' in test_df.columns:
+        test_df['pnl'] = test_df['total_value'].diff().fillna(0)
+    else:
+        test_df['pnl'] = test_df['returns']
+    test_df['date'] = pd.to_datetime(test_df['timestamp']).dt.date
+    avg_daily_pnl = test_df.groupby('date')['pnl'].sum().mean()
 
     print(f'Sharpe Ratio: {sharpe:.4f}')
     print(f'Max Drawdown: {max_drawdown:.4f}')
+    print(f'Rolling Drawdown: {rolling_drawdown:.4f}')
     print(f'Win Rate: {win_rate:.2%}')
+    print(f'Average Daily PnL: {avg_daily_pnl:.4f}')
 
     log_exists = os.path.exists(EVAL_LOG)
     with open(EVAL_LOG, 'a') as f:
@@ -114,7 +127,9 @@ def evaluate():
     pdf.cell(0, 10, f'F1 Score: {f1:.4f}', ln=1)
     pdf.cell(0, 10, f'Sharpe Ratio: {sharpe:.4f}', ln=1)
     pdf.cell(0, 10, f'Max Drawdown: {max_drawdown:.4f}', ln=1)
+    pdf.cell(0, 10, f'Rolling Drawdown: {rolling_drawdown:.4f}', ln=1)
     pdf.cell(0, 10, f'Win Rate: {win_rate:.2%}', ln=1)
+    pdf.cell(0, 10, f'Average Daily PnL: {avg_daily_pnl:.4f}', ln=1)
     pdf.ln(5)
     pdf.image(cm_path, w=170)
     if trend_path:
@@ -126,6 +141,23 @@ def evaluate():
     report_path = os.path.join(REPORTS_DIR, f'report_{ts}.pdf')
     pdf.output(report_path)
     print(f'Report saved to {report_path}')
+
+    # update memory with evaluation metrics
+    mem_path = os.path.join('memory', 'memory.json')
+    os.makedirs('memory', exist_ok=True)
+    memory = {}
+    if os.path.exists(mem_path):
+        try:
+            with open(mem_path, 'r') as f:
+                memory = json.load(f)
+        except Exception:
+            memory = {}
+    memory['last_eval_timestamp'] = str(datetime.now())
+    memory['last_eval_model'] = os.path.basename(MODEL_PATH)
+    memory['last_eval_rolling_drawdown'] = float(rolling_drawdown)
+    memory['last_eval_avg_daily_pnl'] = float(avg_daily_pnl)
+    with open(mem_path, 'w') as f:
+        json.dump(memory, f, indent=2)
 
 if __name__ == '__main__':
     evaluate()

--- a/run_rl_agent.py
+++ b/run_rl_agent.py
@@ -1,6 +1,7 @@
 import os
 import json
 import pandas as pd
+from datetime import datetime
 from stable_baselines3 import PPO
 
 from env_trading import TradingEnv
@@ -44,6 +45,36 @@ def main(model_path: str | None = None):
     logs, final_val = simulate_wallet(actions)
     print(f"Final portfolio value: {final_val:.2f} USDT")
 
+    df_logs = pd.DataFrame(
+        logs,
+        columns=[
+            "timestamp",
+            "price",
+            "signal",
+            "usdt",
+            "coin_value",
+            "total_value",
+            "note",
+            "pnl",
+            "status",
+        ],
+    )
+    if not df_logs.empty:
+        df_logs["timestamp"] = pd.to_datetime(df_logs["timestamp"])
+        df_logs["rolling_max"] = df_logs["total_value"].cummax()
+        df_logs["rolling_drawdown"] = (
+            df_logs["total_value"] - df_logs["rolling_max"]
+        ) / df_logs["rolling_max"]
+        rolling_drawdown = float(df_logs["rolling_drawdown"].min())
+        avg_daily_pnl = (
+            df_logs.groupby(df_logs["timestamp"].dt.date)["pnl"].sum().mean()
+        )
+        print(f"Rolling Drawdown: {rolling_drawdown:.4f}")
+        print(f"Average Daily PnL: {avg_daily_pnl:.4f}")
+    else:
+        rolling_drawdown = 0.0
+        avg_daily_pnl = 0.0
+
     # update memory
     mem_path = os.path.join('memory', 'memory.json')
     memory = {}
@@ -56,6 +87,9 @@ def main(model_path: str | None = None):
     memory['last_rl_reward'] = final_val - env.initial_balance
     memory['last_rl_total_value'] = final_val
     memory['rl_policy'] = os.path.basename(model_path)
+    memory['last_rl_timestamp'] = str(datetime.now())
+    memory['last_rl_rolling_drawdown'] = rolling_drawdown
+    memory['last_rl_avg_daily_pnl'] = avg_daily_pnl
     os.makedirs('memory', exist_ok=True)
     with open(mem_path, 'w') as f:
         json.dump(memory, f, indent=2)


### PR DESCRIPTION
## Summary
- calculate rolling drawdown and average daily PnL in evaluation
- log RL run drawdown and daily PnL
- persist metrics in `memory.json`

## Testing
- `python -m py_compile evaluate_model.py run_rl_agent.py`
- `python evaluate_model.py`
- `python run_rl_agent.py` *(fails: Best model not found)*

------
https://chatgpt.com/codex/tasks/task_b_68869b0861388324918dc90da6237c11