### PR TITLE
Add UpdateManager and composite callback for safer training IO

### DIFF
--- a/config/rl_paths.py
+++ b/config/rl_paths.py
@@ -68,6 +68,39 @@ def build_paths(symbol: str, frame: str,
     paths["kb_file"]     = DEFAULT_KB_FILE
     return paths
 
+
+def get_paths(symbol: str, frame: str) -> dict:
+    """Return a simplified dictionary of important file paths.
+
+    The returned dict matches the keys used by :class:`UpdateManager` and
+    other high level utilities. All paths are relative to the repository
+    root and created on demand.
+    """
+
+    paths = build_paths(symbol, frame)
+    # ensure directories required by UpdateManager
+    os.makedirs(paths["logs"], exist_ok=True)
+    os.makedirs(paths["results"], exist_ok=True)
+    os.makedirs(paths["reports"], exist_ok=True)
+
+    out = {
+        "base": paths["results"],
+        "train_csv": paths["train_csv"],
+        "eval_csv": paths["eval_csv"],
+        "trades_csv": paths["trade_csv"],
+        "step_csv": paths["steps_csv"],
+        "logs_dir": paths["logs"],
+        "jsonl_decisions": paths["decisions_jsonl"],
+        "benchmark_log": paths["benchmark_log"],
+        "risk_log": paths["risk_log"],
+        "report_dir": paths["reports"],
+        "perf_dir": os.path.join(paths["results"], "performance"),
+        "best_zip": paths["model_best_zip"],
+    }
+    # create performance directory lazily
+    os.makedirs(out["perf_dir"], exist_ok=True)
+    return out
+
 def setup_logging(paths: dict):
     root = logging.getLogger()
     root.setLevel(logging.INFO)

--- a/config/update_manager.py
+++ b/config/update_manager.py
@@ -1,0 +1,87 @@
+import os
+import shutil
+import json
+import csv
+import multiprocessing as mp
+from typing import Dict, Optional
+
+from .rl_paths import get_paths
+
+class UpdateManager:
+    """Central coordinator for log/knowledge/report updates.
+
+    The manager is intentionally lightweight; heavy aggregation is
+    deferred to external tooling (e.g. ``tools/knowledge_sync.py``).
+    All file writes occur from the main process only which keeps the
+    code Windows friendly.
+    """
+
+    def __init__(self, paths: Dict[str, str], symbol: str, frame: str, cfg: Optional[Dict] = None) -> None:
+        assert mp.current_process().name == "MainProcess", "UpdateManager must run in MainProcess"
+        self.paths = paths
+        self.symbol = symbol
+        self.frame = frame
+        self.cfg = cfg or {}
+        # ensure required dirs
+        for key in ("logs_dir", "report_dir", "perf_dir"):
+            d = self.paths.get(key)
+            if d:
+                os.makedirs(d, exist_ok=True)
+        # open csv writers lazily
+        self._step_writer = None
+        self._step_fp = None
+
+    # ------------------------------------------------------------------
+    # helpers
+    def _ensure_step_writer(self) -> csv.writer:
+        if self._step_writer is None:
+            os.makedirs(os.path.dirname(self.paths["step_csv"]), exist_ok=True)
+            self._step_fp = open(self.paths["step_csv"], "a", newline="", encoding="utf-8")
+            self._step_writer = csv.writer(self._step_fp)
+        return self._step_writer
+
+    def close(self) -> None:
+        if self._step_fp:
+            try:
+                self._step_fp.close()
+            except Exception:
+                pass
+
+    # ------------------------------------------------------------------
+    # SB3 hook proxies
+    def on_step(self, step: int, metrics: Optional[Dict] = None) -> None:
+        """Record step level metrics to ``step_csv``."""
+        writer = self._ensure_step_writer()
+        metrics = metrics or {}
+        row = [step]
+        for k in sorted(metrics.keys()):
+            row.append(metrics[k])
+        writer.writerow(row)
+        if self._step_fp:
+            self._step_fp.flush()
+
+    def on_rollout_end(self, info: Optional[Dict] = None) -> None:
+        pass  # placeholder for future extensions
+
+    def on_eval_end(self, eval_metrics: Optional[Dict] = None) -> None:
+        if not eval_metrics:
+            return
+        # update best model if requested
+        metric = eval_metrics.get("metric")
+        improved = eval_metrics.get("improved")
+        tmp_path = eval_metrics.get("tmp_path")
+        if improved and tmp_path and os.path.exists(tmp_path):
+            os.makedirs(os.path.dirname(self.paths["best_zip"]), exist_ok=True)
+            shutil.copy2(tmp_path, self.paths["best_zip"])
+
+    def on_training_end(self, summary: Optional[Dict] = None) -> None:
+        self.close()
+        # optionally generate report using external tool
+        if summary and summary.get("report"):
+            try:
+                from tools.generate_markdown_report import generate_report  # type: ignore
+                generate_report(self.symbol, self.frame, self.paths)
+            except Exception:
+                pass
+
+__all__ = ["UpdateManager", "get_paths"]

--- a/tools/knowledge_sync.py
+++ b/tools/knowledge_sync.py
@@ -1,0 +1,45 @@
+import argparse
+import json
+import os
+from pathlib import Path
+
+
+def collect_runs(results_dir: str, agents_dir: str) -> dict:
+    data = {}
+    for sym_dir in Path(results_dir).glob('*'):
+        if not sym_dir.is_dir():
+            continue
+        sym = sym_dir.name
+        for frame_dir in sym_dir.glob('*'):
+            if not frame_dir.is_dir():
+                continue
+            frame = frame_dir.name
+            key = f"{sym}:{frame}"
+            info = {}
+            train_csv = frame_dir / 'train_log.csv'
+            if train_csv.exists():
+                info['has_train'] = True
+            eval_csv = frame_dir / 'evaluation.csv'
+            if eval_csv.exists():
+                info['has_eval'] = True
+            best_model = Path(agents_dir) / sym / frame / 'deep_rl_best.zip'
+            info['has_best_model'] = best_model.exists()
+            data[key] = info
+    return data
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--results-dir', required=True)
+    ap.add_argument('--agents-dir', required=True)
+    ap.add_argument('--out', required=True)
+    args = ap.parse_args()
+
+    summary = collect_runs(args.results_dir, args.agents_dir)
+    os.makedirs(os.path.dirname(args.out), exist_ok=True)
+    with open(args.out, 'w', encoding='utf-8') as f:
+        json.dump(summary, f, indent=2)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- introduce `UpdateManager` to coordinate step logging and best model updates in main process
- add `get_paths` helper and composite callback wired into `Train_RL`
- provide simple `knowledge_sync` tool to aggregate run outputs

## Testing
- `python -m py_compile config/update_manager.py config/rl_paths.py config/rl_callbacks.py tools/knowledge_sync.py Train_RL.py`
- `python tools/knowledge_sync.py --results-dir results --agents-dir agents --out memory/knowledge_base_full.json`


------
https://chatgpt.com/codex/tasks/task_b_68ae4e1cbf8083248f3b630b646d3ee7