### PR TITLE
Fix module imports and config path in training scripts

### DIFF
--- a/Train_ML.py
+++ b/Train_ML.py
@@ -9,9 +9,9 @@ import yaml
 from stable_baselines3 import PPO, A2C, DQN
 from stable_baselines3.common.vec_env import DummyVecEnv, VecNormalize
 import numpy as np
-from env_trading import TradingEnv
+from config.env_trading import TradingEnv
 
-CONFIG_PATH = "config.yaml"
+CONFIG_PATH = os.path.join('config', 'config.yaml')
 if os.path.exists(CONFIG_PATH):     
     with open(CONFIG_PATH, 'r') as f:
         CONFIG = yaml.safe_load(f)

--- a/config/evaluate_all_agents.py
+++ b/config/evaluate_all_agents.py
@@ -1,7 +1,7 @@
 import os
 import glob
 import pandas as pd
-from evaluate import evaluate_trades
+from .evaluate import evaluate_trades
 
 RESULTS_DIR = "results"
 EVAL_FILE = os.path.join(RESULTS_DIR, "evaluation.csv")

--- a/continue_train_agent.py
+++ b/continue_train_agent.py
@@ -1,10 +1,11 @@
 import os
 import json
 import pandas as pd
+import numpy as np
 from datetime import datetime
 from stable_baselines3 import PPO, A2C, DQN
 from stable_baselines3.common.vec_env import DummyVecEnv, VecNormalize
-from env_trading import TradingEnv
+from config.env_trading import TradingEnv
 
 # ==== الإعدادات ====
 AGENT_NAME = "ppo_main"   # عدّل الاسم حسب النموذج المطلوب

--- a/run_rl_agent.py
+++ b/run_rl_agent.py
@@ -12,8 +12,8 @@ import matplotlib.pyplot as plt
 from matplotlib.backends.backend_pdf import PdfPages
 from stable_baselines3 import PPO
 from stable_baselines3.common.vec_env import DummyVecEnv, VecNormalize
-from env_trading import TradingEnv
-from evaluate import evaluate_trades
+from config.env_trading import TradingEnv
+from config.evaluate import evaluate_trades
 
 # Configure root logger
 logging.basicConfig(level=logging.INFO)


### PR DESCRIPTION
## Summary
- correct env_trading imports to use config package
- update Train_ML to load config/config.yaml
- fix evaluate imports and missing numpy dependency

## Testing
- `python -m py_compile Train_ML.py run_rl_agent.py continue_train_agent.py config/evaluate_all_agents.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68ae56cd1f148324ba558431b904ef24