### PR TITLE
Centralize training updates and add live dashboard

### DIFF
--- a/config/rl_callbacks.py
+++ b/config/rl_callbacks.py
@@ -409,7 +409,12 @@ class CompositeCallback(BaseCallback):
         step = int(self.num_timesteps)
         if step % self.step_every == 0:
             try:
-                self.um.on_step(step, {})
+                # funnel periodic step information to the UpdateManager
+                # which in turn is responsible for writing to disk.  The
+                # UpdateManager enforces that only the main process
+                # performs file IO which keeps multi‑processing on
+                # Windows stable.
+                self.um.log_step(step, {})
             except Exception:
                 pass
         return True

--- a/config/rl_paths.py
+++ b/config/rl_paths.py
@@ -46,11 +46,15 @@ def build_paths(symbol: str, frame: str,
     paths["tb_dir"]          = os.path.join(paths["results"], "tb")
 
         # csv
-    paths["steps_csv"]   = os.path.join(paths["results"], f"steps_{frm}.csv")
-    paths["reward_csv"]  = os.path.join(paths["results"], f"reward_{frm}.csv")
-    paths["train_csv"]   = os.path.join(paths["results"], "train_log.csv")
-    paths["eval_csv"]    = os.path.join(paths["results"], "evaluation.csv")
-    paths["trade_csv"]   = os.path.join(paths["results"], "deep_rl_trades.csv")
+    # all csv logs live inside the dedicated logs directory to avoid
+    # cluttering the results root
+    paths["step_csv"]   = os.path.join(paths["logs"], "step_log.csv")
+    paths["steps_csv"] = paths["step_csv"]  # backward compatible key
+    paths["reward_csv"]  = os.path.join(paths["logs"], "reward.csv")
+    paths["train_csv"]   = os.path.join(paths["logs"], "train_log.csv")
+    paths["eval_csv"]    = os.path.join(paths["logs"], "evaluation.csv")
+    paths["trade_csv"]   = os.path.join(paths["logs"], "deep_rl_trades.csv")
+    paths["trades_csv"]  = paths["trade_csv"]  # legacy alias
 
     # state files (global)
     paths["memory_file"] = DEFAULT_MEMORY_FILE
@@ -154,15 +158,21 @@ def get_paths(symbol: str, frame: str) -> dict:
     agents_dir = _mk(DEFAULT_AGENTS_DIR, sym, frm)
     return {
         "base": base,
-        "train_csv": os.path.join(base, "train_log.csv"),
-        "eval_csv": os.path.join(base, "evaluation.csv"),
-        "trades_csv": os.path.join(base, "deep_rl_trades.csv"),
-        "step_csv": os.path.join(base, "step_log.csv"),
         "logs_dir": logs_dir,
+        # csv logs
+        "train_csv": os.path.join(logs_dir, "train_log.csv"),
+        "eval_csv": os.path.join(logs_dir, "evaluation.csv"),
+        "reward_csv": os.path.join(logs_dir, "reward.csv"),
+        "trade_csv": os.path.join(logs_dir, "deep_rl_trades.csv"),
+        "trades_csv": os.path.join(logs_dir, "deep_rl_trades.csv"),  # legacy alias
+        "step_csv": os.path.join(logs_dir, "step_log.csv"),
+        # misc logs
         "jsonl_decisions": os.path.join(logs_dir, "entry_decisions.jsonl"),
         "benchmark_log": os.path.join(logs_dir, "benchmark.log"),
         "risk_log": os.path.join(logs_dir, "risk.log"),
+        # directories for aggregated reports/metrics
         "report_dir": _mk(DEFAULT_RESULTS_DIR, "reports"),
         "perf_dir": _mk(DEFAULT_RESULTS_DIR, "performance"),
+        # best model location
         "best_zip": os.path.join(agents_dir, "deep_rl_best.zip"),
     }

--- a/config/rl_writers.py
+++ b/config/rl_writers.py
@@ -127,7 +127,8 @@ class WritersBundle:
         self.reward    = CSVWriter(paths["reward_csv"], header=["ts","frame","symbol","step","avg_reward","ep_rew_mean"])
         self.trades    = CSVWriter(paths["trade_csv"],  header=["ts","frame","symbol","step","side","price","size","pnl","equity","reason"])
         self.benchmark = CSVWriter(paths["benchmark_log"], header=["ts","frame","symbol","step","fps","cpu_percent","ram_gb","gpu0_mb","gpu1_mb","gpu2_mb","gpu3_mb"])
-        self.error     = CSVWriter(os.path.join(self.paths["results"], "error.csv"), header=["ts","step","message"])
+        # store miscellaneous logs inside the dedicated logs directory
+        self.error     = CSVWriter(os.path.join(self.paths.get("logs", self.paths.get("results")), "error.csv"), header=["ts","step","message"])
         self.train     = CSVWriter(self.paths["train_csv"], header=["ts","frame","symbol","file","timesteps","status"]) 
         self.eval      = CSVWriter(self.paths["eval_csv"],  header=["ts","frame","symbol","metric","value"]) 
 

--- a/config/update_manager.py
+++ b/config/update_manager.py
@@ -1,98 +1,226 @@
-import os
+"""Centralized update manager for training artefacts.
+
+This module centralizes all disk writes that happen during
+reinforcement-learning training.  The intent is to ensure that only the
+main process touches the filesystem which avoids broken pipes on Windows
+and keeps log formats consistent.
+
+The :class:`UpdateManager` exposes a light‑weight API used by
+callbacks/other modules:
+
+``log_step``             – append step level metrics
+``update_performance``   – store evaluation statistics
+``update_best_model``    – keep track of the best checkpoint
+``update_knowledge``     – append structured knowledge events
+
+All information is written under ``results/<SYMBOL>/<FRAME>/logs``.
+"""
+from __future__ import annotations
+
 import csv
 import json
-import shutil
 import logging
 import multiprocessing as mp
+import os
+import shutil
 from datetime import datetime
-from typing import Dict, Any, Optional
+from typing import Any, Dict, Optional
+
+
+def _utcnow() -> str:
+    """Return a compact ISO timestamp."""
+    return datetime.utcnow().isoformat()
 
 
 class UpdateManager:
-    """Central coordinator for logging and model updates.
+    """Coordinate file writes for training output.
 
-    This object must live in the main process and acts as the single
-    gateway for any file IO performed during training.  Worker processes
-    should communicate metrics/events back to the main process via SB3
-    callbacks which call the methods exposed here.
+    Parameters
+    ----------
+    paths: dict
+        Mapping produced by :func:`config.rl_paths.build_paths` /
+        ``get_paths``.  It must contain at least ``logs_dir`` and
+        ``best_zip``.
+    symbol, frame: str
+        Used only for context in logs and reports.
+    cfg: dict, optional
+        Optional configuration dictionary (currently unused but kept for
+        compatibility with older code).
     """
 
-    def __init__(self, paths: Dict[str, str], symbol: str, frame: str, cfg: Optional[Dict[str, Any]] = None):
-        assert mp.current_process().name == "MainProcess", "UpdateManager must run in MainProcess"
+    def __init__(self, paths: Dict[str, str], symbol: str, frame: str,
+                 cfg: Optional[Dict[str, Any]] = None) -> None:
+        if mp.current_process().name != "MainProcess":
+            raise RuntimeError("UpdateManager must run in MainProcess")
+
         self.paths = paths
         self.symbol = symbol
         self.frame = frame
         self.cfg = cfg or {}
 
-        # ensure directories exist
-        for key in ("base", "logs_dir", "report_dir", "perf_dir"):
-            p = self.paths.get(key)
-            if p:
-                os.makedirs(p, exist_ok=True)
+        self.logs_dir = paths.get("logs_dir") or os.path.join(
+            paths.get("base", "results"), "logs"
+        )
+        os.makedirs(self.logs_dir, exist_ok=True)
 
-        # step level csv
-        self._step_path = self.paths.get("step_csv") or self.paths.get("steps_csv")
-        self._step_writer = None
-        if self._step_path:
-            os.makedirs(os.path.dirname(self._step_path) or ".", exist_ok=True)
-            new_file = not os.path.exists(self._step_path)
-            self._step_writer = open(self._step_path, "a", encoding="utf-8", newline="")
-            self._step_csv = csv.writer(self._step_writer)
-            if new_file:
-                self._step_csv.writerow(["ts", "step", "metric", "value"])
+        # ------------------------------------------------------------------
+        # Step CSV
+        step_path = paths.get("step_csv") or os.path.join(self.logs_dir, "step_log.csv")
+        os.makedirs(os.path.dirname(step_path), exist_ok=True)
+        self._step_fh = open(step_path, "a", encoding="utf-8", newline="")
+        self._step_csv = csv.writer(self._step_fh)
+        if os.path.getsize(step_path) == 0:
+            self._step_csv.writerow(["ts", "step", "metric", "value"])
 
-        self._last_eval: Dict[str, Any] = {}
+        # ------------------------------------------------------------------
+        # Performance CSV (aggregated evaluation metrics)
+        perf_path = paths.get("perf_csv") or os.path.join(self.logs_dir, "performance.csv")
+        os.makedirs(os.path.dirname(perf_path), exist_ok=True)
+        self._perf_fh = open(perf_path, "a", encoding="utf-8", newline="")
+        self._perf_csv = csv.writer(self._perf_fh)
+        if os.path.getsize(perf_path) == 0:
+            self._perf_csv.writerow(["ts", "metric", "value"])
+
+        # ------------------------------------------------------------------
+        # Knowledge aggregation
+        self._knowledge_events = os.path.join(self.logs_dir, "knowledge_events.jsonl")
+        self._kb_full = paths.get("kb_file") or os.path.join("memory", "knowledge_base_full.json")
 
     # ------------------------------------------------------------------
-    def on_step(self, step: int, metrics: Optional[Dict[str, Any]] = None) -> None:
-        """Record step metrics to the step CSV."""
-        if self._step_writer is None:
-            return
-        ts = datetime.utcnow().isoformat()
+    # API methods
+    # ------------------------------------------------------------------
+    def log_step(self, step: int, metrics: Optional[Dict[str, Any]] = None) -> None:
+        """Append step level metrics to ``step_log.csv``.
+
+        Parameters
+        ----------
+        step: int
+            Current global step count.
+        metrics: dict, optional
+            Mapping of metric name to value.  If empty, a placeholder row
+            is written so that the step file still reflects progress.
+        """
+
         metrics = metrics or {}
+        if self._step_csv is None:
+            return
+        ts = _utcnow()
         if not metrics:
             self._step_csv.writerow([ts, step, "", ""])
         else:
-            for k, v in metrics.items():
-                self._step_csv.writerow([ts, step, k, v])
-        self._step_writer.flush()
+            for key, value in metrics.items():
+                self._step_csv.writerow([ts, step, key, value])
+        self._step_fh.flush()
 
-    def on_rollout_end(self, info: Optional[Dict[str, Any]] = None) -> None:
-        """Placeholder for rollout end hooks."""
-        # could be used for periodic report generation
+    # Compatibility shim (older code used ``on_step``)
+    def on_step(self, step: int, metrics: Optional[Dict[str, Any]] = None) -> None:  # pragma: no cover - legacy
+        self.log_step(step, metrics)
+
+    def update_performance(self, metrics: Dict[str, Any]) -> None:
+        """Record aggregated evaluation statistics.
+
+        Each key/value pair in ``metrics`` is appended to
+        ``performance.csv`` along with the current timestamp.
+        """
+
+        if not metrics:
+            return
+        ts = _utcnow()
+        for k, v in metrics.items():
+            self._perf_csv.writerow([ts, k, v])
+        self._perf_fh.flush()
+
+    def on_eval_end(self, eval_metrics: Optional[Dict[str, Any]] = None) -> None:  # pragma: no cover - legacy
+        if eval_metrics:
+            self.update_performance(eval_metrics)
+
+    def update_best_model(self, src_path: str, metric: Optional[float] = None) -> None:
+        """Persist the current best checkpoint.
+
+        Parameters
+        ----------
+        src_path: str
+            Path to the newly evaluated model.
+        metric: float, optional
+            Performance metric used to rank the model (e.g., mean reward).
+        """
+
+        if not src_path:
+            return
+        dst = self.paths.get("best_zip") or self.paths.get("model_best_zip")
+        if not dst:
+            return
+        if not os.path.exists(src_path):
+            return
+        os.makedirs(os.path.dirname(dst), exist_ok=True)
+        shutil.copy2(src_path, dst)
+        logging.info("[UpdateManager] saved best model to %s", dst)
+
+        # Record metadata for easy inspection
+        meta_path = self.paths.get("best_meta") or os.path.join(os.path.dirname(dst), "best_ckpt.json")
+        meta = {"ts": _utcnow(), "path": dst}
+        if metric is not None:
+            meta["metric"] = float(metric)
+        try:
+            with open(meta_path, "w", encoding="utf-8") as fh:
+                json.dump(meta, fh, ensure_ascii=False, indent=2)
+        except Exception as exc:  # pragma: no cover
+            logging.warning("[UpdateManager] failed to write %s: %s", meta_path, exc)
+
+    def update_knowledge(self, event: Dict[str, Any]) -> None:
+        """Append a knowledge event and refresh ``knowledge_base_full.json``.
+
+        The event is appended as JSONL to ``knowledge_events.jsonl`` and
+        also merged into the global knowledge base file used by the
+        project.  The knowledge base is treated as a simple list of
+        events for this minimal implementation.
+        """
+
+        if not event:
+            return
+        os.makedirs(os.path.dirname(self._knowledge_events), exist_ok=True)
+        with open(self._knowledge_events, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(event, ensure_ascii=False) + "\n")
+
+        # Aggregate into knowledge_base_full.json
+        kb: list[Any]
+        try:
+            with open(self._kb_full, "r", encoding="utf-8") as fh:
+                kb = json.load(fh)
+            if not isinstance(kb, list):
+                kb = []
+        except Exception:
+            kb = []
+        kb.append(event)
+        try:
+            with open(self._kb_full, "w", encoding="utf-8") as fh:
+                json.dump(kb, fh, ensure_ascii=False, indent=2)
+        except Exception as exc:  # pragma: no cover
+            logging.warning("[UpdateManager] failed to update knowledge base: %s", exc)
+
+    # ------------------------------------------------------------------
+    # Lifecycle helpers
+    # ------------------------------------------------------------------
+    def on_rollout_end(self, info: Optional[Dict[str, Any]] = None) -> None:  # pragma: no cover - placeholder
+        """Hook for end-of-rollout events (currently no-op)."""
         return
 
-    def on_eval_end(self, eval_metrics: Optional[Dict[str, Any]] = None) -> None:
-        """Store last evaluation metrics for later use."""
-        if eval_metrics:
-            self._last_eval = dict(eval_metrics)
-
-    def save_best_model(self, src_path: str, metric: Optional[float] = None) -> None:
-        """Copy improved model checkpoint to configured best path."""
-        try:
-            dst = self.paths.get("best_zip")
-            if src_path and dst and os.path.exists(src_path):
-                os.makedirs(os.path.dirname(dst), exist_ok=True)
-                shutil.copy2(src_path, dst)
-                logging.info("[UpdateManager] saved best model to %s", dst)
-                if metric is not None:
-                    self._last_eval["best_metric"] = float(metric)
-        except Exception as e:  # pragma: no cover
-            logging.warning("[UpdateManager] save_best_model failed: %s", e)
-
     def on_training_end(self, summary: Optional[Dict[str, Any]] = None) -> None:
-        """Finalize writers and generate report if required."""
+        """Finalize writers and optionally persist the best model."""
         if summary:
             best_path = summary.get("best_model_path")
             metric = summary.get("metric")
             if best_path:
-                self.save_best_model(best_path, metric)
-        if self._step_writer is not None:
+                self.update_best_model(best_path, metric)
+        try:
+            self._step_fh.flush()
+            self._perf_fh.flush()
+        finally:
             try:
-                self._step_writer.flush()
+                self._step_fh.close()
             except Exception:
                 pass
             try:
-                self._step_writer.close()
+                self._perf_fh.close()
             except Exception:
                 pass

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -1,0 +1,79 @@
+"""Simple Streamlit dashboard for monitoring training outputs.
+
+The dashboard reads CSV/JSONL logs from ``results/<SYMBOL>/<FRAME>/logs``
+ and visualises basic curves such as reward and trades.  The goal is to
+ provide a light‑weight real‑time view without relying on external
+ services.
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pandas as pd
+import streamlit as st
+
+
+def _load_csv(path: Path) -> pd.DataFrame:
+    try:
+        return pd.read_csv(path)
+    except Exception:
+        return pd.DataFrame()
+
+
+def _load_jsonl(path: Path):
+    items = []
+    if not path.exists():
+        return items
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if line:
+                    try:
+                        items.append(json.loads(line))
+                    except Exception:
+                        pass
+    except Exception:
+        pass
+    return items
+
+
+def main() -> None:
+    st.title("Bot‑Trade Dashboard")
+
+    base = Path(st.sidebar.text_input("Results root", "results"))
+    symbol = st.sidebar.text_input("Symbol", "BTCUSDT").upper()
+    frame = st.sidebar.text_input("Frame", "1m")
+    logs_dir = base / symbol / frame / "logs"
+    st.sidebar.write(f"Logs dir: {logs_dir}")
+
+    reward_df = _load_csv(logs_dir / "reward.csv")
+    trades_df = _load_csv(logs_dir / "deep_rl_trades.csv")
+    bench_df = _load_csv(logs_dir / "benchmark.log")
+    decisions = _load_jsonl(logs_dir / "entry_decisions.jsonl")
+
+    if not reward_df.empty:
+        st.subheader("Reward curve")
+        try:
+            reward_df = reward_df.set_index("step")
+        except Exception:
+            pass
+        st.line_chart(reward_df["avg_reward"])
+
+    if not trades_df.empty:
+        st.subheader("Trade log (last 50)")
+        st.dataframe(trades_df.tail(50))
+
+    if decisions:
+        st.subheader("Recent entry decisions")
+        st.json(decisions[-5:])
+
+    if not bench_df.empty:
+        st.subheader("Benchmark stats")
+        st.dataframe(bench_df.tail(20))
+
+
+if __name__ == "__main__":  # pragma: no cover - manual run
+    main()


### PR DESCRIPTION
## Summary
- replace UpdateManager with unified log/performance/best-model/knowledge API
- move RL logs under `results/<SYMBOL>/<FRAME>/logs` and adjust writers
- expose CompositeCallback to call the centralized manager
- add minimal Streamlit dashboard for monitoring logs

## Testing
- `python -m py_compile config/update_manager.py config/rl_callbacks.py config/rl_paths.py config/rl_writers.py dashboard/app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68ae59cd69148324857898282ad340fe