### PR TITLE
Enable cross-platform monitor launcher and optional monitor windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,14 @@ df = load_binance_data(data_dir, symbol, data_type="trades", freq="1min")
 ## Files
 - `binance_loader.py`
 - Updated project scripts...
+
+## Monitor windows
+
+Helper scripts can be launched in separate consoles using
+`tools/monitor_launch.launch_new_console`. Configure behaviour with environment
+variables:
+
+- `MONITOR_SHELL=cmd|powershell` – force a specific Windows shell.
+- `MONITOR_USE_CONDA_RUN=1` – wrap commands with `conda run` to ensure the
+  active environment.
+- `MONITOR_DEBUG=1` – print the final command line used for spawning.

--- a/Train_RL.py
+++ b/Train_RL.py
@@ -314,7 +314,7 @@ def train_one_file(args, data_file: str) -> bool:
     if not port_state and portfolio_cfg.get("enable"):
         port_state = reset_with_balance(args.symbol, args.frame, portfolio_cfg.get("balance_start", 0.0))
 
-    if getattr(args, "spawn_monitors", True):
+    if getattr(args, "spawn_monitors", False):
         _spawn_monitors(args)
 
     # 2) Device report (optional)

--- a/config/rl_args.py
+++ b/config/rl_args.py
@@ -97,8 +97,12 @@ def parse_args():
     ap.add_argument("--kb-file", type=str, default=DEFAULT_KB_FILE)
     ap.add_argument("--playlist", type=str, default=None)
     ap.add_argument("--mp-start", type=str, default="spawn", choices=["spawn", "forkserver", "fork"])
-    ap.add_argument("--spawn-monitors", action="store_true",
-                    help="Open interactive Monitor Manager in a separate window")
+    ap.add_argument(
+        "--spawn-monitors",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Open interactive Monitor Manager in a separate window",
+    )
     ap.add_argument("--monitor-refresh", type=int, default=10)
     ap.add_argument("--monitor-images-out", type=str,
                     default="exports/{symbol}/{frame}/live")

--- a/tools/monitor_launch.py
+++ b/tools/monitor_launch.py
@@ -1,32 +1,106 @@
-"""Utility to launch monitor scripts in new consoles."""
+"""Cross-platform utility to launch monitor scripts in new consoles."""
 from __future__ import annotations
 
 import os
 import sys
+import shutil
 import subprocess
+import platform
+import shlex
 from typing import List
 
 
-def launch_new_console(title: str, script: str, args: List[str]) -> None:
-    cmd = [sys.executable, script] + args
-    try:
-        if os.name == "nt":
-            subprocess.Popen(["cmd", "/c", "start", title] + cmd,
-                             creationflags=subprocess.CREATE_NEW_CONSOLE)
-        elif sys.platform == "darwin":
-            apple = [
-                "osascript", "-e",
-                'tell app "Terminal" to do script "%s"' % " ".join(cmd)
-            ]
-            subprocess.Popen(apple)
+def _ps_quote(arg: str) -> str:
+    return "'" + arg.replace("'", "''") + "'"
+
+
+def _ps_command(parts: List[str]) -> str:
+    return "& " + " ".join(_ps_quote(p) for p in parts)
+
+
+def _cmd_command(parts: List[str]) -> str:
+    out: List[str] = []
+    for p in parts:
+        if not p:
+            out.append('""')
+        elif any(ch in p for ch in [' ', '\t', '"']):
+            out.append('"' + p.replace('"', r'\"') + '"')
         else:
-            term = os.environ.get("MONITOR_TERM")
-            if term:
-                subprocess.Popen([term, "--", "bash", "-lc", " ".join(cmd)])
+            out.append(p)
+    return " ".join(out)
+
+
+def launch_new_console(title: str, script: str, args: List[str]) -> None:
+    """Launch ``script`` with ``args`` in a new console window."""
+    base_cmd = [sys.executable, script] + list(args)
+
+    use_conda = os.environ.get("MONITOR_USE_CONDA_RUN") == "1"
+    conda_exe = shutil.which("conda") if use_conda else None
+    conda_env = os.environ.get("CONDA_DEFAULT_ENV")
+    if use_conda and conda_exe and conda_env:
+        base_cmd = [conda_exe, "run", "--no-capture-output", "-n", conda_env] + base_cmd
+
+    debug = os.environ.get("MONITOR_DEBUG") == "1"
+    system = platform.system()
+    prefer_shell = os.environ.get("MONITOR_SHELL", "powershell").lower()
+
+    if system == "Windows":
+        wt = shutil.which("wt")
+        if prefer_shell.startswith("power"):
+            ps_cmd = _ps_command(base_cmd)
+            ps_cmd = f"[console]::Title={_ps_quote(title)}; {ps_cmd}"
+            if wt:
+                final_cmd = [wt, "nt", "powershell", "-NoExit", "-Command", ps_cmd]
+                label = "WT PowerShell"
             else:
-                try:
-                    subprocess.Popen(["gnome-terminal", "--", "bash", "-lc", " ".join(cmd)])
-                except Exception:
-                    subprocess.Popen(cmd)
-    except Exception:
-        subprocess.Popen(cmd)
+                final_cmd = ["powershell", "-NoExit", "-Command", ps_cmd]
+                label = "PowerShell"
+        else:
+            cmdline = _cmd_command(base_cmd)
+            cmdline = f"title {title} & {cmdline}"
+            if wt:
+                final_cmd = [wt, "nt", "cmd", "/k", cmdline]
+                label = "WT CMD"
+            else:
+                final_cmd = ["cmd", "/k", cmdline]
+                label = "CMD"
+        if debug:
+            print(f"[MONITOR] {label}:", " ".join(final_cmd))
+        subprocess.Popen(final_cmd, creationflags=subprocess.CREATE_NEW_CONSOLE)
+        return
+
+    if system == "Darwin":
+        cmd_str = " ".join(shlex.quote(p) for p in base_cmd)
+        osa = [
+            "osascript",
+            "-e",
+            f'tell application "Terminal" to do script {shlex.quote(cmd_str)}'
+        ]
+        if debug:
+            print("[MONITOR]", osa)
+        subprocess.Popen(osa)
+        return
+
+    cmd_str = " ".join(shlex.quote(p) for p in base_cmd)
+    terminals: List[str] = []
+    term_env = os.environ.get("MONITOR_TERM")
+    if term_env:
+        terminals.append(term_env)
+    terminals.extend(["gnome-terminal", "konsole", "xterm", "alacritty"])
+
+    for term in terminals:
+        if shutil.which(term):
+            if term == "gnome-terminal":
+                final_cmd = [term, "--", "bash", "-lc", cmd_str]
+            elif term in ("konsole", "alacritty", "xterm"):
+                final_cmd = [term, "-e", "bash", "-lc", cmd_str]
+            else:
+                continue
+            if debug:
+                print("[MONITOR]", final_cmd)
+            subprocess.Popen(final_cmd)
+            return
+
+    if debug:
+        print("[MONITOR]", base_cmd)
+    subprocess.Popen(base_cmd)


### PR DESCRIPTION
## Summary
- replace ad-hoc console spawning with `tools/monitor_launch.py` and add support for Windows Terminal, PowerShell, cmd, macOS and Linux
- add `--spawn-monitors/--no-spawn-monitors` flags to training and bot entrypoints and launch resource/report monitors when enabled
- document monitor environment toggles in README
- refine Windows command and debug handling for monitor launcher

## Testing
- `python -m py_compile tools/monitor_launch.py Train_RL.py run_bot.py config/rl_args.py`
- `python Train_RL.py --help`
- `python run_bot.py --help` *(fails: ModuleNotFoundError: No module named 'env_config')*


------
https://chatgpt.com/codex/tasks/task_b_68b0bb4af29483248eb4893b2a5c2baf