### PR TITLE
chore: robust tools imports and memory system

### DIFF
--- a/DEV_NOTES.md
+++ b/DEV_NOTES.md
@@ -1,0 +1,14 @@
+# Developer Notes
+
+## Running tools directly vs module mode
+
+Project helper scripts live under the `tools/` package. When executing these
+scripts it is recommended to run them as modules from the project root, e.g.
+
+```bash
+python -m tools.export_charts --help
+```
+
+This ensures that the project root is on `sys.path` and avoids `ImportError`
+issues. For convenience the scripts also include a small `sys.path` fix-up so
+that direct execution (`python tools/export_charts.py`) still works if needed.

--- a/Makefile
+++ b/Makefile
@@ -32,5 +32,8 @@ docker-build:
 	docker build -t $(IMAGE_NAME) .
 
 docker-run:
-	docker run --rm -it $(IMAGE_NAME)
+        docker run --rm -it $(IMAGE_NAME)
+
+devmap:
+        python -m tools.generate_dev_map > docs/bot_map.md
 

--- a/README.md
+++ b/README.md
@@ -46,3 +46,13 @@ variables:
 - `MONITOR_USE_CONDA_RUN=1` – wrap commands with `conda run` to ensure the
   active environment.
 - `MONITOR_DEBUG=1` – print the final command line used for spawning.
+
+## Memory and resume
+
+Training runs persist state in `memory/` and can resume automatically.
+Invoke training with `--auto-resume` to continue from the latest snapshot.
+Inspect saved state with:
+
+```
+python -m tools.memory_cli --print-latest
+```

--- a/Train_RL.py
+++ b/Train_RL.py
@@ -60,6 +60,7 @@ from config.env_config import get_config
 import shutil
 from stable_baselines3.common.callbacks import EvalCallback
 from tools.run_state import load_state as load_run_state, save_state as save_run_state
+from tools.memory_manager import MemoryManager
 from ai_core.portfolio import (
     load_state as load_portfolio_state,
     save_state as save_portfolio_state,
@@ -594,6 +595,9 @@ def main():
     args = validate_args(args)
     args = finalize_args(args, is_continuous=None)  # allow builders to decide SDE later
 
+    mm = MemoryManager()
+    mm.log_event("start", {"args": vars(args)})
+
     # Ensure resume-auto can accept optional value
     if not hasattr(args, "resume_auto"):
         import argparse
@@ -634,6 +638,8 @@ def main():
         raise FileNotFoundError(f"No data files for {args.symbol}-{args.frame}")
     data_file = files[0]
     train_one_file(args, data_file)
+    mm.snapshot({"data_file": data_file})
+    mm.log_event("end", {"status": "ok"})
 
 
 if __name__ == "__main__":

--- a/ai_core/ai_dashboard.py
+++ b/ai_core/ai_dashboard.py
@@ -1,5 +1,4 @@
-"""Streamlit dashboard for monitoring training outputs (read-only)."""
-"""Streamlit dashboard for live training metrics.
+"""Streamlit dashboard for monitoring training outputs (read-only).
 
 Run with:
     streamlit run ai_core/ai_dashboard.py

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -1,0 +1,355 @@
+# =========================
+# bot_trade — config.yaml
+# آخر تحديث: 2025-08-10
+# =========================
+
+project:
+  seed: 42
+  debug: true
+  dtype: float32
+  paths:
+    data_dir: "data"          # بيانات خام/جاهزة (feather)
+    ready_dir: "data_ready"   # مخرجات prepare_data_ready.py
+    agents_dir: "agents"
+    logs_dir: "logs"
+    results_dir: "results"
+    reports_dir: "reports"
+    memory_dir: "memory"
+  report_formats: ["csv","png","pdf"]  # لما نفعّل تقارير التحليل الآلي:contentReference[oaicite:4]{index=4}
+
+defaults:
+  symbol: "BTCUSDT"
+  frame: "1m"                 # يقرأها Env عند الإنشاء (fallback):contentReference[oaicite:5]{index=5}
+  split_by_year_1s: false     # لو أردت تقسيم 1s حسب السنة بدل quantiles
+  save_per_symbol: true       # GroupBy(save per symbol) كما اتفقنا
+  fill_missing_safe_zero: true # ملء الأعمدة الناقصة بصفر آمنًا
+
+# ————— تهيئة التدريب التعزيزي (SB3 / PPO) —————
+rl:
+  algorithm: "PPO"
+  policy: "MlpPolicy"
+  normalize_obs: true         # VecNormalize (obs فقط)
+  normalize_reward: false
+  # parallel envs لكل عملية (نعدّلها من سكربت التشغيل حسب الـCPU)
+  n_envs:
+    "1s": 24
+    "1m": 20
+    "3m": 16
+    "5m": 16
+  # طول الرول‑آوت لكل فريم (يتحقق Train_RL من القابلية وحجم البيانات)
+  n_steps:
+    "1s": 16384      # 8k–32k مقترح، اخترنا وسطًا أعلى للثواني
+    "1m": 4096
+    "3m": 4096
+    "5m": 4096
+  batch_size: 2048
+  n_epochs: 10
+  gamma: 0.999
+  gae_lambda: 0.95
+  clip_range: 0.2
+  ent_coef: 0.005 
+  vf_coef: 0.5
+  learning_rate: 2e-4
+  max_grad_norm: 0.5
+  target_kl: null
+  # نقاط حفظ/استئناف
+  checkpoint_every_steps: 500_000
+  keep_last_n: 5
+  resume_if_found: true
+
+# ————— بيئة التداول —————
+env:
+  frame: "${defaults.frame}"  # يُمكن تمريره من CLI؛ هذا الافتراضي يظهر في info:contentReference[oaicite:6]{index=6}
+  symbol: "$(defaults.symbol)" #  
+  max_steps: null             # يكتشف تلقائيًا من طول الملف إذا null:contentReference[oaicite:7]{index=7}
+  initial_balance_usdt: 10000
+  commission_pct: 0.0004
+  slippage_pct: 0.0003
+  spread_pct: 0.0001
+  allow_hold_across_steps: true
+  risk_manager:
+    min_risk: 0.05
+    max_risk: 0.5
+    ema_reward_alpha: 0.05
+    freeze_loss_streak: 6
+    recovery_ema_threshold: 0.0
+    danger_vol_threshold: 0.035
+    notes_in_info: true       # يمرّر أسباب التعديل ضمن info
+  reward:
+    pnl_weight: 1.0
+    vol_penalty_weight: 0.25
+    dd_penalty_weight: 0.35
+    bonus_trend_align: 0.05
+    benchmark_buy_and_hold: true
+  smart_entry_guard:
+    enabled: true             # entry_verifier + simulation_engine:contentReference[oaicite:8]{index=8}
+    simulation_threshold: 0.55
+    allow_if_sim_positive: true
+    cool_down_steps: 0
+
+# ————— الميزات والمؤشرات —————
+indicators:
+  enabled:
+    rsi: true
+    bollinger: true
+    macd: true
+    ema: true
+    sma: true
+    atr: true
+    adx: true
+    donchian: true
+    vortex: true
+    keltner: true
+    obv: true
+    cci: true
+    stochastic: true
+    roc: true
+    ao: true
+  windows:
+    rsi_window: 14
+    bb_window: 20
+    bb_dev: 2.0
+    ema_window: 20
+    sma_window: 50
+    atr_window: 14
+    adx_window: 14
+    donchian_window: 20
+    vi_window: 14
+    kc_window: 20
+    kc_atr_window: 10
+    ao_short_window: 5
+    ao_long_window: 34
+    stoch_window: 14
+    stoch_smooth_window: 3
+
+signals:
+  # سيجنتشرات جاهزة كما في modules: trend/mean‑reversion/breakout + ML اختياري:contentReference[oaicite:9]{index=9}
+  use_entry_signals: true
+  use_freeze_signals: true
+  use_danger_signals: true
+  use_recovery_signals: true
+  # Mapping اختياري لتأثير الإشارات داخل الـ reward/risk
+  weights:
+    trend_follow: 1.0
+    mean_reversion: 0.5
+    breakout_buy: 0.7
+    breakout_sell: 0.7
+    ml_signal: 0.6
+
+ai_core:
+  enable_self_improver: true
+  knowledge_base_path: "memory/knowledge_base_full.json"
+  post_training_analysis: true   # tools/analyze_risk_and_training.py hook:contentReference[oaicite:10]{index=10}
+  update_config_from_hints: true # قراءة tuning_hints.json للجلسة التالية:contentReference[oaicite:11]{index=11}
+
+data_ready:
+  output_dir: "data_ready"
+  format: "feather"          # feather فقط (بدون CSV)
+  float_dtype: "float32"
+  # سياسة الدمج والاستخراج:
+  merge:
+    "1s":
+      method: "quantiles"    # بديله "year" — غيّر لـ split-by-year بسهولة
+      parts: 8
+    "1m":
+      method: "single_file"
+    "3m":
+      method: "single_file"
+    "5m":
+      method: "single_file"
+
+evaluation:
+  do_eval_every: 1_000_000
+  eval_episodes: 3
+  save_trades_csv: true
+  save_reward_curve_png: true
+  metrics: ["sharpe","maxdd","winrate"]
+
+tmux_runner:
+  use_gpu_affinity: true
+  per_process_env:
+    OMP_NUM_THREADS: 8
+    PYTORCH_CUDA_ALLOC_CONF: "expandable_segments:True"
+  # مثال التشغيل الموازي (مرشد فقط؛ التنفيذ من سكربت tmux)
+  plans:
+    - name: "1s_duo"
+      gpus: [0,1]
+      frame: "1s"
+      seeds: [11,22]
+      shards: [0,1]
+    - name: "1m_duo"
+      gpus: [2,3]
+      frame: "1m"
+      seeds: [33,44]
+      shards: [0,1]
+
+data:
+  raw_dir: "data"           # مكان البيانات الخام (كما وصفت)
+  out_dir: "data_ready"     # مكان الإخراج الجديد
+  frames: ["1s","1m","3m","5m"]
+  group_by_symbol: true     # حفظ لكل Symbol على حدة
+  enforce_float32: true     # كل أعمدة الأسعار/الأحجام تُحفظ float32
+  fill_missing_with_zero: true
+
+  split:
+    "1s":
+      mode: "year"     # بدّلها إلى "year" لو عايز التقسيم بالسنة
+      parts: 8              # عدد الأجزاء عند mode=quantiles
+      # لو mode=year يتم تجاهل parts
+
+  # أسماء الأعمدة التي نضمن موجودة بالنتيجة (ترتيب يعكس بايبلايننا)
+  enforce_columns:
+    - timestamp
+    - datetime
+    - symbol
+    - frame
+    - open
+    - high
+    - low
+    - close
+    - volume
+    - quote_volume
+    - num_trades
+    - taker_buy_base
+    - taker_buy_quote
+
+
+# ==== pipeline toggles ====
+logging:
+  step_every: 100
+  rollout_report_every: 1
+
+reports:
+  enable: true
+  every_rollouts: 1
+
+knowledge:
+  enable: true
+  run_after_training: true
+
+dashboard:
+  enable: true
+
+eval:
+  enable: true
+  n_episodes: 5
+  save_best: true
+  metric: "ep_rew_mean"
+
+policy_kwargs:
+  net_arch: [512, 512, 256]
+  activation_fn: "ReLU"
+  ortho_init: true
+
+ppo:
+  n_envs: 16
+  n_steps: 2048
+  batch_size: 8192
+  learning_rate: 0.0003
+  gamma: 0.999
+  gae_lambda: 0.95
+  clip_range: 0.2
+  n_epochs: 10
+  lr_schedule: linear_warmup_cosine
+  warmup_steps: 10000
+
+risk_manager:
+  dynamic_sizing: true
+  min_pct: 0.1
+  max_pct: 2.0
+  max_drawdown_stop: 0.25
+
+multiprocessing:
+  start_method: "spawn"
+
+writers:
+  mainprocess_only: true
+
+policy_kwargs:
+  net_arch: [512, 512, 256]
+  activation_fn: "ReLU"
+  ortho_init: true
+
+eval:
+  enable: true
+  n_episodes: 5
+  eval_freq: 5000
+  save_best: true
+  patience_eval_rounds: 3
+  lr_decay_factor: 0.5
+  lr_decay_limit: 2
+
+logging:
+  step_every: 100
+  rollout_report_every: 1
+
+knowledge:
+  enable: true
+  run_after_training: true
+
+dashboard:
+  enable: true
+
+reward_shaping:
+  w_pnl: 1.0
+  w_volatility: 0.35
+  w_drawdown: 0.5
+  w_trade_cost: 0.1
+  w_dwell: 0.01
+
+curriculum:
+  enable: true
+  regime_metric: volatility
+  start_quantile: 0.3
+  end_quantile: 1.0
+  ramp_steps: 200000
+
+self_learning:
+  enable: true
+  writeback_config: false
+
+monitors:
+  enable: true
+  refresh: 10
+  images_out: "exports/{symbol}/{frame}/live"
+  spawn_on_train: true
+  manager_only: true
+resources:
+  enable: true
+  refresh: 1
+anomaly:
+  refresh: 10
+  stalled_sec: 120
+  dd_warn: 0.15
+  block_rate_warn: 0.40
+export:
+  svg: false
+  limit_rows: 250000
+analytics:
+  reward_aliases: ["avg_reward","ep_rew_mean","mean_reward","episode_reward","reward"]
+  equity_aliases: ["equity","pnl","cum_pnl","balance"]
+  penalties_aliases: ["penalty","risk_penalty","slippage_penalty","time_penalty","vol_penalty"]
+  signals_min_support: 20
+
+resume:
+  enable: true
+  strict_offsets: true
+  rng: true
+
+knowledge:
+  enable: true
+  build_embeddings: true
+  summarize_every: 600   # seconds
+  propose_config: true
+  apply_proposals: false
+
+portfolio:
+  enable: true
+  balance_start: 1000.0
+  equity_guard_band: 0.1
+  snapshot_every: 300  # seconds to write portfolio snapshots
+
+risk_manager:
+  dynamic_sizing: true
+  max_drawdown_stop: 0.25
+  reduce_size_below_equity: 0.2

--- a/docs/bot_map.md
+++ b/docs/bot_map.md
@@ -1,0 +1,100 @@
+# Bot Architecture Map
+
+## High-level Flow
+
+```
+[CLI] -> [Config] -> [Data Loading] -> [Env] -> [Agent] -> [Writers] -> [Memory] -> [Reports/Results] -> [Monitors]
+```
+
+## Module Inventory
+
+- ai_core.__init__
+- ai_core.ai_dashboard
+- ai_core.convert
+- ai_core.dashboard_io
+- ai_core.entry_verifier
+- ai_core.portfolio
+- ai_core.self_improver
+- ai_core.simulation_engine
+- ai_core.strategy_learner
+- config.__init__
+- config.env_config
+- config.env_trading
+- config.evaluate
+- config.evaluate_all_agents
+- config.evaluate_enhanced
+- config.loader
+- config.log_setup
+- config.market_data
+- config.results_logger
+- config.risk_manager
+- config.rl_args
+- config.rl_builders
+- config.rl_callbacks
+- config.rl_paths
+- config.rl_writers
+- config.signals.danger_signals
+- config.signals.entry_signals
+- config.signals.freeze_signals
+- config.signals.recovery_signals
+- config.signals.reward_signals
+- config.signals.signals_bridge
+- config.strategy_features
+- config.update_manager
+- tools.__init__
+- tools.analytics_common
+- tools.analyze_risk_and_training
+- tools.analyze_sessions
+- tools.anomaly_watch
+- tools.apply_config_proposal
+- tools.binance_klines_feather
+- tools.bootstrap
+- tools.cli_console
+- tools.data_aggregator
+- tools.export_charts
+- tools.fast
+- tools.generate_dev_map
+- tools.generate_markdown_report
+- tools.knowledge_hub
+- tools.knowledge_sync
+- tools.live_ticker
+- tools.make_config_override
+- tools.memory_cli
+- tools.memory_index
+- tools.memory_manager
+- tools.memory_store
+- tools.merge_feather_files
+- tools.monitor_launch
+- tools.monitor_manager
+- tools.paths
+- tools.resource_monitor
+- tools.run_state
+- tools.runctx
+- tools.self_improver
+- tools.session_learning_engine
+- tools.tuning_engine
+
+## Runtime Flow
+
+1. Parse CLI args
+2. Load configuration
+3. Build data loaders and env
+4. Instantiate agent
+5. Train/evaluate with writers
+6. Persist memory and knowledge
+7. Generate reports and launch monitors
+
+## Inputs/Outputs
+
+- configs: config/*.py
+- data: results/{symbol}/{frame}/
+- reports: report/{symbol}/{frame}/{run_id}/
+- logs: logs/{symbol}/{frame}/{run_id}/
+
+## Environment Variables
+
+- MONITOR_SHELL, MONITOR_DEBUG, MONITOR_USE_CONDA_RUN
+
+## Adding new tools
+
+Place new scripts under tools/ and ensure absolute imports.

--- a/docs/notes.md
+++ b/docs/notes.md
@@ -1,0 +1,3 @@
+# Notes
+
+Placeholder for maintainer notes.

--- a/scripts/gen_dev_map.ps1
+++ b/scripts/gen_dev_map.ps1
@@ -1,0 +1,1 @@
+python -m tools.generate_dev_map > docs/bot_map.md

--- a/tools/analyze_risk_and_training.py
+++ b/tools/analyze_risk_and_training.py
@@ -1,3 +1,5 @@
+from tools import bootstrap  # noqa: F401  # Import path fixup when run directly
+
 import os
 import json
 from typing import Dict
@@ -5,7 +7,7 @@ from typing import Dict
 import numpy as np
 import pandas as pd
 
-from .analytics_common import (
+from tools.analytics_common import (
     load_steps_df,
     load_reward_df,
     compute_equity,

--- a/tools/analyze_sessions.py
+++ b/tools/analyze_sessions.py
@@ -5,6 +5,8 @@ exposes functions that return pandas DataFrames/Series so other tools
 can reuse the logic.  The command line behaviour is kept for backward
 compatibility."""
 
+from tools import bootstrap  # noqa: F401  # Import path fixup when run directly
+
 import os
 from typing import Dict
 
@@ -12,7 +14,7 @@ import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 
-from .analytics_common import (
+from tools.analytics_common import (
     load_trades_df,
     compute_equity,
     compute_drawdown,

--- a/tools/anomaly_watch.py
+++ b/tools/anomaly_watch.py
@@ -3,8 +3,13 @@ from __future__ import annotations
 
 import argparse
 import os
+import threading
 import time
-from datetime import datetime
+from datetime import datetime, timezone
+
+from tools import bootstrap  # noqa: F401  # Import path fixup when run directly
+
+import json
 
 from tools.analytics_common import (
     load_reward_df,
@@ -13,6 +18,8 @@ from tools.analytics_common import (
     wait_for_first_write,
     artifact_paths,
 )
+from tools.paths import results_dir, report_dir, logs_dir
+from tools.runctx import atomic_write_json
 
 import numpy as np
 import pandas as pd
@@ -45,38 +52,65 @@ def main():
     ap = argparse.ArgumentParser()
     ap.add_argument('--symbol', default='BTCUSDT')
     ap.add_argument('--frame', default='1m')
-    ap.add_argument('--base', default='results')
+    ap.add_argument('--base')
     ap.add_argument('--refresh', type=int, default=10)
     ap.add_argument('--stalled-sec', type=int, default=120)
     ap.add_argument('--dd-warn', type=float, default=0.15)
     ap.add_argument('--no-wait', action='store_true')
+    ap.add_argument('--run-id', required=True)  # NOTE: interface changed here - run_id now required to namespace outputs
     args = ap.parse_args()
 
-    log_file = os.path.join('exports', args.symbol, args.frame, 'alerts.log')
-    os.makedirs(os.path.dirname(log_file), exist_ok=True)
-
+    base_dir = args.base or str(results_dir(args.symbol, args.frame))
     if not args.no_wait:
-        wait_for_first_write(args.base, args.symbol, args.frame)
+        wait_for_first_write(base_dir, args.symbol, args.frame)
 
-    paths = artifact_paths(args.base, args.symbol, args.frame)
+    paths = artifact_paths(base_dir, args.symbol, args.frame)
+    log_dir = logs_dir(args.symbol, args.frame, args.run_id)
+    rep_dir = report_dir(args.symbol, args.frame, args.run_id)
+    log_file = log_dir / "anomalies.log"
+    rep_file = rep_dir / "anomalies.json"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    rep_dir.mkdir(parents=True, exist_ok=True)
 
-    while True:
-        reward = load_reward_df(args.base, args.symbol, args.frame)
-        trades = load_trades_df(args.base, args.symbol, args.frame)
-        eq = compute_equity(trades)
-        alerts = []
-        if check_stall(paths, args.stalled_sec):
-            alerts.append('training stalled')
-        if check_nan_reward(reward):
-            alerts.append('NaN reward')
-        if check_drawdown(eq, args.dd_warn):
-            alerts.append('drawdown high')
-        if alerts:
-            msg = f"[{datetime.utcnow().isoformat()}] " + ", ".join(alerts)
-            print(msg)
-            with open(log_file,'a',encoding='utf-8') as fh:
-                fh.write(msg+'\n')
-        time.sleep(max(1,args.refresh))
+    stop_event = threading.Event()
+    try:
+        while not stop_event.is_set():
+            reward = load_reward_df(base_dir, args.symbol, args.frame)
+            trades = load_trades_df(base_dir, args.symbol, args.frame)
+            eq = compute_equity(trades)
+            anomalies = []
+            if check_stall(paths, args.stalled_sec):
+                anomalies.append({
+                    "name": "training_stalled",
+                    "value": args.stalled_sec,
+                    "severity": "critical",
+                    "source": "artifact_mtime",
+                })
+            if check_nan_reward(reward):
+                anomalies.append({
+                    "name": "nan_reward",
+                    "value": 1,
+                    "severity": "high",
+                    "source": "reward_csv",
+                })
+            if check_drawdown(eq, args.dd_warn):
+                anomalies.append({
+                    "name": "drawdown_high",
+                    "value": float(args.dd_warn),
+                    "severity": "warn",
+                    "source": "equity",
+                })
+            ts = datetime.now(timezone.utc).isoformat()
+            if anomalies:
+                print(f"[{ts}] anomalies detected: {anomalies}")
+            else:
+                print(f"[{ts}] none detected")
+            with open(log_file, "a", encoding="utf-8") as fh:
+                fh.write(json.dumps({"ts": ts, "anomalies": anomalies}) + "\n")
+            atomic_write_json(rep_file, {"ts": ts, "anomalies": anomalies})
+            stop_event.wait(max(1, args.refresh))
+    except KeyboardInterrupt:
+        pass
 
 
 if __name__ == '__main__':

--- a/tools/bootstrap.py
+++ b/tools/bootstrap.py
@@ -1,0 +1,14 @@
+"""Project root path bootstrap for standalone scripts.
+
+Importing this module ensures the repository root is on ``sys.path`` so
+absolute imports like ``from tools.analytics_common import ...`` work even when
+scripts are executed directly via ``python tools/xyz.py``.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tools/generate_dev_map.py
+++ b/tools/generate_dev_map.py
@@ -1,0 +1,64 @@
+"""Generate developer-oriented architecture map in Markdown."""
+from __future__ import annotations
+
+from tools import bootstrap  # noqa: F401  # Import path fixup when run directly
+
+import argparse
+import inspect
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+BLOCK = """
+[CLI] -> [Config] -> [Data Loading] -> [Env] -> [Agent] -> [Writers] -> [Memory] -> [Reports/Results] -> [Monitors]
+"""
+
+
+def module_inventory() -> list[str]:
+    mods = []
+    for pkg in ["ai_core", "config", "tools"]:
+        p = ROOT / pkg
+        for py in p.rglob("*.py"):
+            rel = py.relative_to(ROOT).with_suffix("")
+            mods.append(str(rel).replace("/", "."))
+    return sorted(mods)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Generate dev map")
+    args = ap.parse_args()
+    mods = module_inventory()
+
+    print("# Bot Architecture Map\n")
+    print("## High-level Flow\n")
+    print("```")
+    print(BLOCK.strip())
+    print("```")
+    print("\n## Module Inventory\n")
+    for m in mods:
+        print(f"- {m}")
+    print("\n## Runtime Flow\n")
+    flow = [
+        "Parse CLI args",
+        "Load configuration",
+        "Build data loaders and env",
+        "Instantiate agent",
+        "Train/evaluate with writers",
+        "Persist memory and knowledge",
+        "Generate reports and launch monitors",
+    ]
+    for i, step in enumerate(flow, 1):
+        print(f"{i}. {step}")
+    print("\n## Inputs/Outputs\n")
+    print("- configs: config/*.py")
+    print("- data: results/{symbol}/{frame}/")
+    print("- reports: report/{symbol}/{frame}/{run_id}/")
+    print("- logs: logs/{symbol}/{frame}/{run_id}/")
+    print("\n## Environment Variables\n")
+    print("- MONITOR_SHELL, MONITOR_DEBUG, MONITOR_USE_CONDA_RUN")
+    print("\n## Adding new tools\n")
+    print("Place new scripts under tools/ and ensure absolute imports.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/generate_markdown_report.py
+++ b/tools/generate_markdown_report.py
@@ -1,6 +1,8 @@
 """Minimal Markdown report generator for training sessions."""
 from __future__ import annotations
 
+from tools import bootstrap  # noqa: F401  # Import path fixup when run directly
+
 import os
 from datetime import datetime
 from typing import Dict

--- a/tools/memory_cli.py
+++ b/tools/memory_cli.py
@@ -1,0 +1,31 @@
+"""Small CLI to inspect and manage training memory state."""
+from __future__ import annotations
+
+from tools import bootstrap  # noqa: F401  # Import path fixup when run directly
+
+import argparse
+import json
+
+from tools.memory_manager import MemoryManager
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Inspect memory state")
+    ap.add_argument("--print-latest", action="store_true", help="Print latest snapshot")
+    ap.add_argument("--resume", action="store_true", help="Resume and print state")
+    ap.add_argument("--compact", action="store_true", help="Write compact index entry")
+    args = ap.parse_args()
+
+    mm = MemoryManager()
+    if args.print_latest or args.resume:
+        state = mm.resume()
+        print(json.dumps(state, indent=2))
+    if args.compact:
+        mm.compact()
+        print("compacted")
+    if not any([args.print_latest, args.resume, args.compact]):
+        ap.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/memory_manager.py
+++ b/tools/memory_manager.py
@@ -1,0 +1,53 @@
+"""Unified memory manager for resumable training and analysis."""
+from __future__ import annotations
+
+from tools import bootstrap  # noqa: F401  # Import path fixup when run directly
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict
+
+from tools.paths import DIR_MEMORY, ensure_dirs
+from tools.runctx import atomic_write_json, lockfile
+
+
+def _ts() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class MemoryManager:
+    """Append-only event log with periodic state snapshots."""
+
+    def __init__(self, base_dir: Path = DIR_MEMORY) -> None:
+        self.base_dir = base_dir
+        ensure_dirs(self.base_dir)
+        self.events_file = self.base_dir / "events.jsonl"
+        self.state_file = self.base_dir / "state_latest.json"
+        self.index_file = self.base_dir / "state_index.jsonl"
+
+    def log_event(self, event_type: str, payload: Dict[str, Any]) -> None:
+        entry = {"type": event_type, "ts": _ts(), **payload}
+        lock = self.events_file.with_suffix(".lock")
+        ensure_dirs(self.base_dir)
+        with lockfile(lock):
+            with self.events_file.open("a", encoding="utf-8") as fh:
+                fh.write(json.dumps(entry) + "\n")
+
+    def snapshot(self, state: Dict[str, Any]) -> None:
+        data = {"updated_at": _ts(), **state}
+        atomic_write_json(self.state_file, data)
+
+    def resume(self) -> Dict[str, Any]:
+        if self.state_file.exists():
+            with self.state_file.open("r", encoding="utf-8") as fh:
+                return json.load(fh)
+        return {}
+
+    def compact(self) -> None:
+        size = self.events_file.stat().st_size if self.events_file.exists() else 0
+        entry = {"ts": _ts(), "size": size}
+        lock = self.index_file.with_suffix(".lock")
+        with lockfile(lock):
+            with self.index_file.open("a", encoding="utf-8") as fh:
+                fh.write(json.dumps(entry) + "\n")

--- a/tools/memory_store.py
+++ b/tools/memory_store.py
@@ -1,0 +1,41 @@
+"""Simple persistent memory store with atomic updates."""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict
+
+from tools.paths import DIR_MEMORY, ensure_dirs
+from tools.runctx import atomic_write_json
+
+MEMORY_FILE = DIR_MEMORY / "memory.json"
+
+
+def load() -> Dict:
+    if MEMORY_FILE.exists():
+        try:
+            return json.loads(MEMORY_FILE.read_text(encoding="utf-8"))
+        except Exception:
+            return {}
+    return {}
+
+
+def save(data: Dict) -> None:
+    ensure_dirs(DIR_MEMORY)
+    atomic_write_json(MEMORY_FILE, data)
+
+
+def update(partial: Dict) -> Dict:
+    data = load()
+    data.update(partial)
+    data["updated_at"] = datetime.now(timezone.utc).isoformat()
+    save(data)
+    return data
+
+
+def checkpoint(run_id: str, step: int, extra: Dict | None = None) -> Dict:
+    payload = {"run_id": run_id, "step": step}
+    if extra:
+        payload.update(extra)
+    return update(payload)

--- a/tools/monitor_launch.py
+++ b/tools/monitor_launch.py
@@ -8,6 +8,9 @@ import subprocess
 import platform
 import shlex
 from typing import List
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
 
 
 def _ps_quote(arg: str) -> str:
@@ -30,9 +33,9 @@ def _cmd_command(parts: List[str]) -> str:
     return " ".join(out)
 
 
-def launch_new_console(title: str, script: str, args: List[str]) -> None:
-    """Launch ``script`` with ``args`` in a new console window."""
-    base_cmd = [sys.executable, script] + list(args)
+def launch_new_console(title: str, module: str, args: List[str]) -> None:
+    """Launch ``module`` with ``args`` in a new console window."""
+    base_cmd = [sys.executable, "-m", module] + list(args)
 
     use_conda = os.environ.get("MONITOR_USE_CONDA_RUN") == "1"
     conda_exe = shutil.which("conda") if use_conda else None
@@ -66,7 +69,7 @@ def launch_new_console(title: str, script: str, args: List[str]) -> None:
                 label = "CMD"
         if debug:
             print(f"[MONITOR] {label}:", " ".join(final_cmd))
-        subprocess.Popen(final_cmd, creationflags=subprocess.CREATE_NEW_CONSOLE)
+        subprocess.Popen(final_cmd, creationflags=subprocess.CREATE_NEW_CONSOLE, cwd=ROOT)
         return
 
     if system == "Darwin":
@@ -78,7 +81,7 @@ def launch_new_console(title: str, script: str, args: List[str]) -> None:
         ]
         if debug:
             print("[MONITOR]", osa)
-        subprocess.Popen(osa)
+        subprocess.Popen(osa, cwd=ROOT)
         return
 
     cmd_str = " ".join(shlex.quote(p) for p in base_cmd)
@@ -98,9 +101,9 @@ def launch_new_console(title: str, script: str, args: List[str]) -> None:
                 continue
             if debug:
                 print("[MONITOR]", final_cmd)
-            subprocess.Popen(final_cmd)
+            subprocess.Popen(final_cmd, cwd=ROOT)
             return
 
     if debug:
         print("[MONITOR]", base_cmd)
-    subprocess.Popen(base_cmd)
+    subprocess.Popen(base_cmd, cwd=ROOT)

--- a/tools/monitor_manager.py
+++ b/tools/monitor_manager.py
@@ -1,14 +1,14 @@
 """Interactive monitor manager for training session."""
 from __future__ import annotations
 
+from tools import bootstrap  # noqa: F401  # Import path fixup when run directly
+
 import argparse
-import os
 from typing import List
 
 from tools.analytics_common import wait_for_first_write
 from tools.monitor_launch import launch_new_console
-
-TOOLS_DIR = os.path.dirname(__file__)
+from tools.paths import results_dir, report_dir
 
 MENU = """
 === MONITOR MANAGER (symbol={symbol} frame={frame}) ===
@@ -27,15 +27,18 @@ def main() -> None:
     ap.add_argument('--frame', default='1m')
     ap.add_argument('--refresh', type=int, default=10)
     ap.add_argument('--images-out')
-    ap.add_argument('--base', default='results')
+    ap.add_argument('--base')
+    ap.add_argument('--run-id', required=True)  # NOTE: interface changed here - run_id required for path namespacing
     ap.add_argument('--no-wait', action='store_true')
     args = ap.parse_args()
 
     img_dir = args.images_out.format(symbol=args.symbol, frame=args.frame) if args.images_out else None
 
+    base_dir = args.base or str(results_dir(args.symbol, args.frame))
+
     if not args.no_wait:
         print('Waiting for first log write...', flush=True)
-        wait_for_first_write(args.base, args.symbol, args.frame)
+        wait_for_first_write(base_dir, args.symbol, args.frame)
 
     while True:
         try:
@@ -49,36 +52,39 @@ def main() -> None:
                 '--symbol', args.symbol,
                 '--frame', args.frame,
                 '--refresh', str(args.refresh),
-                '--base', args.base,
+                '--base', base_dir,
+                '--run-id', args.run_id,
             ]
             if img_dir:
                 args_list += ['--images-out', img_dir]
-            launch_new_console('LIVE-TICKER', os.path.join(TOOLS_DIR, 'live_ticker.py'), args_list)
+            launch_new_console('LIVE-TICKER', 'tools.live_ticker', args_list)
         elif choice == 'c':
-            launch_new_console('CLI-CONSOLE', os.path.join(TOOLS_DIR, 'cli_console.py'), [
+            launch_new_console('CLI-CONSOLE', 'tools.cli_console', [
                 '--symbol', args.symbol,
                 '--frame', args.frame,
-                '--base', args.base,
+                '--base', base_dir,
             ])
         elif choice == 'a':
-            launch_new_console('ANOMALY-WATCH', os.path.join(TOOLS_DIR, 'anomaly_watch.py'), [
+            launch_new_console('ANOMALY-WATCH', 'tools.anomaly_watch', [
                 '--symbol', args.symbol,
                 '--frame', args.frame,
                 '--refresh', str(args.refresh),
-                '--base', args.base,
+                '--base', base_dir,
+                '--run-id', args.run_id,
             ])
         elif choice == 'r':
-            launch_new_console('RESOURCE-MON', os.path.join(TOOLS_DIR, 'resource_monitor.py'), [
+            launch_new_console('RESOURCE-MON', 'tools.resource_monitor', [
                 '--symbol', args.symbol,
                 '--frame', args.frame,
-                '--base', args.base,
+                '--base', base_dir,
             ])
         elif choice == 'e':
-            out = img_dir or os.path.join('exports', args.symbol, args.frame, 'batch')
-            launch_new_console('BATCH-EXPORT', os.path.join(TOOLS_DIR, 'export_charts.py'), [
+            out = img_dir or str(report_dir(args.symbol, args.frame, args.run_id))
+            launch_new_console('BATCH-EXPORT', 'tools.export_charts', [
                 '--symbol', args.symbol,
                 '--frame', args.frame,
-                '--base', args.base,
+                '--base', base_dir,
+                '--run-id', args.run_id,
                 '--out', out,
             ])
             print(f'Exporting to {out}', flush=True)

--- a/tools/paths.py
+++ b/tools/paths.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+
+# Project root resolved from this file location
+ROOT = Path(__file__).resolve().parents[1]
+
+# Core directories
+DIR_RESULTS = ROOT / "results"
+DIR_AGENTS = ROOT / "agents"
+DIR_MEMORY = ROOT / "memory"
+DIR_KNOWLEDGE = DIR_MEMORY / "knowledge"
+DIR_REPORT = ROOT / "report"  # NOTE: interface changed here - renamed from export to report
+DIR_LOGS = ROOT / "logs"
+
+
+def ensure_dirs(*paths: Path) -> None:
+    """Ensure that each of ``paths`` exists."""
+    for p in paths:
+        p.mkdir(parents=True, exist_ok=True)
+
+
+def results_dir(symbol: str, frame: str) -> Path:
+    """Return the legacy results directory for ``symbol``/``frame``."""
+    p = DIR_RESULTS / symbol / frame
+    ensure_dirs(p)
+    return p
+
+
+def agents_dir(symbol: str, frame: str) -> Path:
+    """Return the agents directory for ``symbol``/``frame``."""
+    p = DIR_AGENTS / symbol / frame
+    ensure_dirs(p)
+    return p
+
+
+def report_dir(symbol: str, frame: str, run_id: str) -> Path:
+    """Return the run specific report directory."""
+    p = DIR_REPORT / symbol / frame / run_id
+    ensure_dirs(p)
+    return p
+
+
+def logs_dir(symbol: str, frame: str, run_id: str) -> Path:
+    """Return the run specific logs directory."""
+    p = DIR_LOGS / symbol / frame / run_id
+    ensure_dirs(p)
+    return p

--- a/tools/runctx.py
+++ b/tools/runctx.py
@@ -1,0 +1,71 @@
+"""Run context helpers: run id generation and atomic filesystem utils."""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict
+
+from tools.paths import (
+    ROOT,
+    results_dir,
+    report_dir,
+    logs_dir,
+    agents_dir,
+)
+
+
+def _git_hash() -> str:
+    try:
+        out = subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"], cwd=ROOT
+        ).decode().strip()
+        return out
+    except Exception:
+        return "nogit"
+
+
+def new_run_id(symbol: str, frame: str) -> str:
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H-%M-%SZ")
+    gh = _git_hash()[:7]
+    return f"{symbol}-{frame}-{ts}-{gh}"
+
+
+def run_paths(symbol: str, frame: str, run_id: str) -> Dict[str, Path]:
+    return {
+        "results": results_dir(symbol, frame),
+        "report": report_dir(symbol, frame, run_id),
+        "logs": logs_dir(symbol, frame, run_id),
+        "agents": agents_dir(symbol, frame),
+    }
+
+
+def atomic_write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(text, encoding="utf-8")
+    tmp.replace(path)
+
+
+def atomic_write_json(path: Path, data: Dict) -> None:
+    atomic_write_text(path, json.dumps(data, indent=2, ensure_ascii=False))
+
+
+@contextmanager
+def lockfile(path: Path):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as fh:
+        try:
+            if os.name == "posix":
+                import fcntl
+
+                fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+            yield fh
+        finally:
+            if os.name == "posix":
+                import fcntl
+
+                fcntl.flock(fh.fileno(), fcntl.LOCK_UN)


### PR DESCRIPTION
## Summary
- centralise path bootstrapping via `tools.bootstrap` and convert tools to absolute imports
- add `MemoryManager` with CLI, integrate start/end snapshots into `Train_RL.py`
- provide repo architecture map generator and example config

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python Train_RL.py -h`
- `python -m tools.monitor_manager --help`
- `python -m tools.generate_markdown_report --help`
- `python -m tools.memory_cli --print-latest`


------
https://chatgpt.com/codex/tasks/task_b_68b0f2ea3b988324b97deaad4ce38f8d