### PR TITLE
Improve training stability and Windows packaging

### DIFF
--- a/ai_core/ai_dashboard.py
+++ b/ai_core/ai_dashboard.py
@@ -8,19 +8,12 @@ or from project root:
 
 from __future__ import annotations
 
-import sys, pathlib
-from pathlib import Path
 from typing import Dict
 
 import pandas as pd
 import streamlit as st
 
-# allow running from subdirectories without PYTHONPATH tweaks
-root = pathlib.Path(__file__).resolve().parents[1]
-if str(root) not in sys.path:
-    sys.path.insert(0, str(root))
-
-from ai_core.dashboard_io import (
+from .dashboard_io import (
     load_decisions,
     load_training_metrics,
     load_trades,

--- a/config/env_config.py
+++ b/config/env_config.py
@@ -1,8 +1,13 @@
 import logging
 logging.basicConfig(level=logging.INFO)
-from dotenv import load_dotenv
 import os
 import yaml
+
+try:
+    from dotenv import load_dotenv
+except Exception:  # pragma: no cover - optional dependency
+    def load_dotenv(*args, **kwargs):
+        return False
 
 # Load variables from .env if present
 load_dotenv()

--- a/config/log_setup.py
+++ b/config/log_setup.py
@@ -183,6 +183,7 @@ def stop_logging(log_objs: Optional[LogObjects]) -> None:
         log_objs.listener.stop()
     except Exception:
         pass
+    logging.shutdown()
 
 
 # Convenience helpers ---------------------------------------------------------

--- a/config/signals/__init__.py
+++ b/config/signals/__init__.py
@@ -1,0 +1,1 @@
+"""Signal modules for trading environment."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,12 @@
 [build-system]
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[project]
+name = "bot-trade"
+version = "0.1.0"
+dependencies = []
+
+[tool.setuptools]
+packages = ["bot_trade"]
+package-dir = {"bot_trade" = "."}

--- a/run_multi_gpu.py
+++ b/run_multi_gpu.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-run_multi_gpu.py — مُشغّل متوازي/تسلسلي يقرأ playlist.yaml ويشغّل Train_RL.py على عدّة GPUs أو بالتتابع.
+run_multi_gpu.py — مُشغّل متوازي/تسلسلي يقرأ playlist.yaml ويشغّل train_rl.py على عدّة GPUs أو بالتتابع.
 
 المزايا:
 - تشغيل كل Job في عملية مستقلة (متزامن) مع تمرير --device الصحيح.
@@ -65,7 +65,7 @@ def _truthy(x: Any) -> bool:
 
 
 def build_cmd(python_bin: str, job: Dict[str, Any], post_analyze: bool) -> List[str]:
-    cmd: List[str] = [python_bin, "-u", "Train_RL.py"]
+    cmd: List[str] = [python_bin, "-u", "-m", "bot_trade.train_rl"]
 
     consumed: set = set()
 

--- a/scripts/tmux_train_overrides.sh
+++ b/scripts/tmux_train_overrides.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 SESSION="bot-train"
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BASE_CFG="${ROOT}/config/config.yaml"
-ENTRY="python Train_RL.py"         # عدّل لو عندك اسم مختلف
+ENTRY="python -m bot_trade.train_rl"         # عدّل لو عندك اسم مختلف
 DATE_TAG="$(date +'%Y%m%d_%H%M%S')"
 
 # خرائط التشغيل: GPU/FRAME/SEED/N_ENVS/N_STEPS/BATCH/GAMMA/LR/STACK

--- a/tools/bootstrap.py
+++ b/tools/bootstrap.py
@@ -1,14 +1,5 @@
-"""Project root path bootstrap for standalone scripts.
+"""Legacy bootstrap module.
 
-Importing this module ensures the repository root is on ``sys.path`` so
-absolute imports like ``from tools.analytics_common import ...`` work even when
-scripts are executed directly via ``python tools/xyz.py``.
+Project is now a proper package; keeping this module as a no-op for
+backwards compatibility.
 """
-from __future__ import annotations
-
-import sys
-from pathlib import Path
-
-ROOT = Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))


### PR DESCRIPTION
## Summary
- reopen performance metrics lazily and add idempotent close in UpdateManager
- throttle noisy risk logs and allow running without python-dotenv
- package cleanup: rename train_rl, absolute imports, updated pyproject and scripts

## Testing
- `python -m py_compile config/update_manager.py config/risk_manager.py ai_core/ai_dashboard.py train_rl.py run_multi_gpu.py tools/bootstrap.py config/log_setup.py`  
- `python -m py_compile config/env_config.py`  
- `pip install -e .`  
- `python -m bot_trade.train_rl --help`  
- `python -m bot_trade.run_multi_gpu --help`

------
https://chatgpt.com/codex/tasks/task_b_68b1fa428b00832dadad078cca447b06