### PR TITLE
Centralize memory paths and root detection

### DIFF
--- a/autolearn.py
+++ b/autolearn.py
@@ -127,18 +127,19 @@ def main():
     plt.savefig(os.path.join(REPORTS_DIR, f"confusion_matrix_{timestamp}.png"))
     plt.close()
 
-    memory_path = os.path.join("memory", "memory.json")
+    from bot_trade.config.rl_paths import ensure_utf8, memory_dir
+
+    memory_path = memory_dir() / "memory.json"
     memory = {}
-    if os.path.exists(memory_path):
+    if memory_path.exists():
         try:
-            with open(memory_path, "r") as f:
-                memory = json.load(f)
+            memory = json.loads(memory_path.read_text(encoding="utf-8"))
         except Exception:
             memory = {}
     memory["last_training_accuracy"] = best_f1
     memory["last_training_model"] = model_name
-    with open(memory_path, "w") as f:
-        json.dump(memory, f, indent=2)
+    with ensure_utf8(memory_path, csv_newline=False) as fh:
+        json.dump(memory, fh, indent=2)
 
     logging.info(f"Model Accuracy: {accuracy:.4f}")
     logging.info(f"F1 Score: {best_f1:.4f} using {model_name}")

--- a/bot_trade/ai_core/dashboard_io.py
+++ b/bot_trade/ai_core/dashboard_io.py
@@ -1,9 +1,13 @@
 import os
 import json
-import pandas as pd
+import json
+import os
+from pathlib import Path
 from typing import Dict
 
-from bot_trade.config.rl_paths import get_paths
+import pandas as pd
+
+from bot_trade.config.rl_paths import get_paths, memory_dir
 
 
 def _read_csv(path: str) -> pd.DataFrame:
@@ -44,9 +48,10 @@ def load_benchmark(symbol: str, frame: str) -> pd.DataFrame:
     return _read_csv(paths.get("benchmark_log", ""))
 
 
-def load_knowledge(path: str = "memory/knowledge_base_full.json") -> Dict:
+def load_knowledge(path: str | None = None) -> Dict:
+    if path is None:
+        path = memory_dir() / "knowledge_base_full.json"
     try:
-        with open(path, "r", encoding="utf-8") as f:
-            return json.load(f)
+        return json.loads(Path(path).read_text(encoding="utf-8"))
     except Exception:
         return {}

--- a/bot_trade/ai_core/entry_verifier.py
+++ b/bot_trade/ai_core/entry_verifier.py
@@ -6,8 +6,14 @@
 # - Safe defaults when config/KB is missing
 
 from __future__ import annotations
-import json, os, traceback
+
+import json
+import os
+import traceback
+from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional
+
+from bot_trade.config.rl_paths import ensure_utf8, memory_dir
 
 try:
     from bot_trade.config.signals_bridge import map_human_to_standard
@@ -23,27 +29,25 @@ except Exception:
     def simulate_entry(close_series, signal_time_idx: int, **kwargs) -> int:
         return 0
 
-KB_FILE = "memory/knowledge_base_full.json"
+KB_FILE = memory_dir() / "knowledge_base_full.json"
 
 # ---------------------------
 # KB helpers
 # ---------------------------
 
-def _load_json(path: str) -> Dict[str, Any]:
+def _load_json(path: Path) -> Dict[str, Any]:
     try:
-        if not os.path.exists(path):
+        if not path.exists():
             return {}
-        with open(path, "r", encoding="utf-8") as f:
-            return json.load(f)
+        return json.loads(path.read_text(encoding="utf-8"))
     except Exception:
         return {}
 
 
-def _save_json(path: str, data: Dict[str, Any]) -> None:
+def _save_json(path: Path, data: Dict[str, Any]) -> None:
     try:
-        os.makedirs(os.path.dirname(path), exist_ok=True)
-        with open(path, "w", encoding="utf-8") as f:
-            json.dump(data, f, ensure_ascii=False, indent=2)
+        with ensure_utf8(path, csv_newline=False) as fh:
+            json.dump(data, fh, ensure_ascii=False, indent=2)
     except Exception:
         pass
 

--- a/bot_trade/ai_core/self_improver.py
+++ b/bot_trade/ai_core/self_improver.py
@@ -1,50 +1,53 @@
 # ai_core/self_improver.py
 # Adapt config using both KB (long-term) and latest session analytics
 from __future__ import annotations
-import os, json, yaml
-from typing import Dict, Any
+
 from datetime import datetime
+from pathlib import Path
+from typing import Dict, Any
 
-KB_PATH = "memory/knowledge_base_full.json"
+import json
+import os
+import yaml
+
+from bot_trade.config.rl_paths import ensure_utf8, memory_dir
+
+KB_PATH = memory_dir() / "knowledge_base_full.json"
 CONFIG_PATH = os.getenv("BOT_CONFIG", os.path.join("config", "config.yaml"))
-SUCCESS_PATH = os.path.join("memory", "success_patterns.json")
-FAILURE_PATH = os.path.join("memory", "failure_insights.json")
+SUCCESS_PATH = memory_dir() / "success_patterns.json"
+FAILURE_PATH = memory_dir() / "failure_insights.json"
 
 
-def _load_json(path: str) -> Dict[str, Any]:
+def _load_json(path: Path) -> Dict[str, Any]:
     try:
-        if not os.path.exists(path):
+        if not path.exists():
             return {}
-        with open(path, "r", encoding="utf-8") as f:
-            return json.load(f)
+        return json.loads(path.read_text(encoding="utf-8"))
     except Exception:
         return {}
 
 
-def _save_json(path: str, data: Dict[str, Any]) -> None:
+def _save_json(path: Path, data: Dict[str, Any]) -> None:
     try:
-        os.makedirs(os.path.dirname(path), exist_ok=True)
-        with open(path, "w", encoding="utf-8") as f:
-            json.dump(data, f, ensure_ascii=False, indent=2)
+        with ensure_utf8(path, csv_newline=False) as fh:
+            json.dump(data, fh, ensure_ascii=False, indent=2)
     except Exception:
         pass
 
 
-def _load_yaml(path: str) -> Dict[str, Any]:
+def _load_yaml(path: Path) -> Dict[str, Any]:
     try:
-        if not os.path.exists(path):
+        if not path.exists():
             return {}
-        with open(path, "r", encoding="utf-8") as f:
-            return yaml.safe_load(f) or {}
+        return yaml.safe_load(path.read_text(encoding="utf-8")) or {}
     except Exception:
         return {}
 
 
-def _save_yaml(path: str, data: Dict[str, Any]) -> None:
+def _save_yaml(path: Path, data: Dict[str, Any]) -> None:
     try:
-        os.makedirs(os.path.dirname(path), exist_ok=True)
-        with open(path, "w", encoding="utf-8") as f:
-            yaml.safe_dump(data, f, sort_keys=False, allow_unicode=True)
+        with ensure_utf8(path, csv_newline=False) as fh:
+            yaml.safe_dump(data, fh, sort_keys=False, allow_unicode=True)
     except Exception:
         pass
 

--- a/bot_trade/ai_core/strategy_learner.py
+++ b/bot_trade/ai_core/strategy_learner.py
@@ -3,28 +3,33 @@
 from __future__ import annotations
 import os, json
 from collections import defaultdict
+from collections import defaultdict
+from pathlib import Path
 from typing import Dict, Any
+
+import json
+import os
 import pandas as pd
 
-KB_FILE = "memory/knowledge_base_full.json"
+from bot_trade.config.rl_paths import ensure_utf8, memory_dir
+
+KB_FILE = memory_dir() / "knowledge_base_full.json"
 STEP_LOG = os.getenv("STEP_LOG", os.path.join("results", "step_log.csv"))
 
 
-def _load_json(path: str) -> Dict[str, Any]:
+def _load_json(path: Path) -> Dict[str, Any]:
     try:
-        if not os.path.exists(path):
+        if not path.exists():
             return {}
-        with open(path, "r", encoding="utf-8") as f:
-            return json.load(f)
+        return json.loads(path.read_text(encoding="utf-8"))
     except Exception:
         return {}
 
 
-def _save_json(path: str, data: Dict[str, Any]) -> None:
+def _save_json(path: Path, data: Dict[str, Any]) -> None:
     try:
-        os.makedirs(os.path.dirname(path), exist_ok=True)
-        with open(path, "w", encoding="utf-8") as f:
-            json.dump(data, f, ensure_ascii=False, indent=2)
+        with ensure_utf8(path, csv_newline=False) as fh:
+            json.dump(data, fh, ensure_ascii=False, indent=2)
     except Exception:
         pass
 

--- a/bot_trade/run_bot.py
+++ b/bot_trade/run_bot.py
@@ -4,9 +4,12 @@ import os
 import subprocess
 import argparse
 from datetime import datetime
-import yaml
+
 import pandas as pd
+import yaml
+
 from env_config import LIVE_TRADING
+from bot_trade.config.rl_paths import memory_dir
 
 CONFIG_PATH = 'config.yaml'
 
@@ -118,7 +121,7 @@ def main(args):
                     'tools/knowledge_sync.py',
                     '--results-dir', 'results',
                     '--agents-dir', 'agents',
-                    '--out', os.path.join('memory', 'knowledge_base_full.json'),
+                    '--out', str(memory_dir() / 'knowledge_base_full.json'),
                 ], check=False)
             except Exception:
                 pass

--- a/bot_trade/run_multi_gpu.py
+++ b/bot_trade/run_multi_gpu.py
@@ -28,6 +28,8 @@ import json
 import yaml
 import argparse
 import subprocess
+
+from bot_trade.config.rl_paths import memory_dir
 from datetime import datetime
 from typing import Dict, Any, List, Optional, Tuple
 
@@ -299,7 +301,7 @@ def main():
                 "--agents-dir",
                 "agents",
                 "--out",
-                os.path.join("memory", "knowledge_base_full.json"),
+                str(memory_dir() / "knowledge_base_full.json"),
             ], check=False)
         except Exception:
             pass

--- a/bot_trade/tools/knowledge_sync.py
+++ b/bot_trade/tools/knowledge_sync.py
@@ -13,7 +13,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, Iterable
 
-from bot_trade.tools.paths import DIR_KNOWLEDGE, ensure_dirs
+from bot_trade.config.rl_paths import ensure_utf8, memory_dir
+from bot_trade.tools.paths import ensure_dirs
 from bot_trade.tools.runctx import atomic_write_json
 
 
@@ -31,7 +32,8 @@ def write_knowledge(run_id: str, summary: str, *, references: Iterable[str] | No
     A compact dictionary is stored to ``memory/knowledge/knowledge-{run_id}.json``
     and an entry is appended to ``memory/knowledge/log.jsonl``.
     """
-    ensure_dirs(DIR_KNOWLEDGE)
+    dir_knowledge = memory_dir() / "knowledge"
+    ensure_dirs(dir_knowledge)
     data: Dict[str, object] = {
         "run_id": run_id,
         "summary": summary,
@@ -42,10 +44,10 @@ def write_knowledge(run_id: str, summary: str, *, references: Iterable[str] | No
         "references": list(references or []),
         "created_at": _ts(),
     }
-    path = DIR_KNOWLEDGE / f"knowledge-{run_id}.json"
+    path = dir_knowledge / f"knowledge-{run_id}.json"
     atomic_write_json(path, data)
-    log_path = DIR_KNOWLEDGE / "log.jsonl"
-    with log_path.open("a", encoding="utf-8") as fh:
+    log_path = dir_knowledge / "log.jsonl"
+    with ensure_utf8(log_path, csv_newline=False) as fh:
         fh.write(json.dumps(data) + "\n")
     return path
 

--- a/bot_trade/tools/memory_manager.py
+++ b/bot_trade/tools/memory_manager.py
@@ -9,7 +9,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict
 
-from bot_trade.tools.paths import DIR_MEMORY, ROOT, ensure_dirs
+from bot_trade.config.rl_paths import get_root, memory_dir
+from bot_trade.tools.paths import ensure_dirs
 from bot_trade.tools.runctx import atomic_write_json, lockfile
 
 
@@ -58,8 +59,8 @@ class MemoryManager:
 # Memory v2 helpers
 # =============================
 
-PROJECT_ROOT = ROOT.parent
-MEM_DIR = PROJECT_ROOT / "memory"
+PROJECT_ROOT = get_root()
+MEM_DIR = memory_dir()
 MEMORY_FILE = MEM_DIR / "memory.json"
 
 
@@ -76,7 +77,7 @@ def _default_memory(root: Path = PROJECT_ROOT) -> Dict[str, Any]:
 
 def load_memory(root: Path = PROJECT_ROOT) -> Dict[str, Any]:
     """Load memory.json upgrading to schema v2 if needed."""
-    path = Path(root) / "memory" / "memory.json"
+    path = (memory_dir() if root == PROJECT_ROOT else Path(root) / "memory") / "memory.json"
     if not path.exists():
         return _default_memory(root)
     try:
@@ -174,7 +175,7 @@ def commit_snapshot(run_id: str, snapshot: Dict[str, Any], root: Path = PROJECT_
     mem = load_memory(root)
     mem.setdefault("runs", {})[run_id] = snapshot
     mem["last_run_id"] = run_id
-    path = Path(root) / "memory" / "memory.json"
+    path = (memory_dir() if root == PROJECT_ROOT else Path(root) / "memory") / "memory.json"
     ensure_dirs(path.parent)
     tmp = path.with_suffix(".tmp")
     tmp.write_text(json.dumps(mem, ensure_ascii=False, indent=2), encoding="utf-8")

--- a/bot_trade/tools/memory_store.py
+++ b/bot_trade/tools/memory_store.py
@@ -6,10 +6,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict
 
-from bot_trade.tools.paths import DIR_MEMORY, ensure_dirs
+from bot_trade.config.rl_paths import memory_dir
+from bot_trade.tools.paths import ensure_dirs
 from bot_trade.tools.runctx import atomic_write_json
 
-MEMORY_FILE = DIR_MEMORY / "memory.json"
+MEMORY_FILE = memory_dir() / "memory.json"
 
 
 def load() -> Dict:

--- a/bot_trade/tools/monitor_manager.py
+++ b/bot_trade/tools/monitor_manager.py
@@ -11,6 +11,8 @@ import sys
 from pathlib import Path
 from typing import List, Optional
 
+from bot_trade.config.rl_paths import memory_dir
+
 
 MENU = """
 === MONITOR MANAGER (symbol={symbol} frame={frame}) ===
@@ -66,7 +68,7 @@ def auto_run_id(symbol: str, frame: str, root: Path) -> Optional[str]:
         rid = read_run_id_from_csv(c)
         if rid:
             return rid
-    mem_file = root / "memory" / "memory.json"
+    mem_file = memory_dir() / "memory.json"
     if mem_file.exists():
         try:
             data = json.loads(mem_file.read_text(encoding="utf-8"))

--- a/bot_trade/tools/paths.py
+++ b/bot_trade/tools/paths.py
@@ -1,14 +1,23 @@
 from pathlib import Path
 
-# Project root resolved from this file location
-ROOT = Path(__file__).resolve().parents[1]
+from bot_trade.config.rl_paths import (
+    agents_dir as _agents_dir,
+    get_root,
+    logs_dir as _logs_dir,
+    memory_dir as _memory_dir,
+    reports_dir as _reports_dir,
+    results_dir as _results_dir,
+)
 
-# Core directories
+# Project root resolved via rl_paths
+ROOT = get_root()
+
+# Core directories anchored at ROOT
 DIR_RESULTS = ROOT / "results"
 DIR_AGENTS = ROOT / "agents"
-DIR_MEMORY = ROOT / "memory"
+DIR_MEMORY = _memory_dir()
 DIR_KNOWLEDGE = DIR_MEMORY / "knowledge"
-DIR_REPORT = ROOT / "report"  # NOTE: interface changed here - renamed from export to report
+DIR_REPORT = ROOT / "reports"
 DIR_LOGS = ROOT / "logs"
 
 
@@ -19,28 +28,20 @@ def ensure_dirs(*paths: Path) -> None:
 
 
 def results_dir(symbol: str, frame: str) -> Path:
-    """Return the legacy results directory for ``symbol``/``frame``."""
-    p = DIR_RESULTS / symbol / frame
-    ensure_dirs(p)
-    return p
+    """Return the results directory for ``symbol``/``frame``."""
+    return _results_dir(symbol, frame)
 
 
 def agents_dir(symbol: str, frame: str) -> Path:
     """Return the agents directory for ``symbol``/``frame``."""
-    p = DIR_AGENTS / symbol / frame
-    ensure_dirs(p)
-    return p
+    return _agents_dir(symbol, frame)
 
 
-def report_dir(symbol: str, frame: str, run_id: str) -> Path:
-    """Return the run specific report directory."""
-    p = DIR_REPORT / symbol / frame / run_id
-    ensure_dirs(p)
-    return p
+def report_dir(symbol: str, frame: str, run_id: str) -> Path:  # noqa: ARG001
+    """Return the report directory (run_id ignored for compatibility)."""
+    return _reports_dir(symbol, frame)
 
 
-def logs_dir(symbol: str, frame: str, run_id: str) -> Path:
-    """Return the run specific logs directory."""
-    p = DIR_LOGS / symbol / frame / run_id
-    ensure_dirs(p)
-    return p
+def logs_dir(symbol: str, frame: str, run_id: str) -> Path:  # noqa: ARG001
+    """Return the logs directory under results (run_id ignored)."""
+    return _logs_dir(symbol, frame)

--- a/bot_trade/tools/run_state.py
+++ b/bot_trade/tools/run_state.py
@@ -1,25 +1,26 @@
 import argparse
 import json
 import os
+from pathlib import Path
 from typing import Dict
 
-RUN_STATE_PATH = os.path.join('memory', 'run_state.json')
+from bot_trade.config.rl_paths import ensure_utf8, memory_dir
+
+RUN_STATE_PATH = memory_dir() / 'run_state.json'
 
 
-def load_state(path: str = RUN_STATE_PATH) -> Dict:
-    if not os.path.exists(path):
+def load_state(path: Path = RUN_STATE_PATH) -> Dict:
+    if not path.exists():
         return {}
-    with open(path, 'r', encoding='utf-8') as fh:
-        try:
-            return json.load(fh)
-        except Exception:
-            return {}
+    try:
+        return json.loads(path.read_text(encoding='utf-8'))
+    except Exception:
+        return {}
 
 
-def save_state(state: Dict, path: str = RUN_STATE_PATH) -> None:
-    os.makedirs(os.path.dirname(path), exist_ok=True)
-    tmp = path + '.tmp'
-    with open(tmp, 'w', encoding='utf-8') as fh:
+def save_state(state: Dict, path: Path = RUN_STATE_PATH) -> None:
+    tmp = path.with_suffix('.tmp')
+    with ensure_utf8(tmp, csv_newline=False) as fh:
         json.dump(state, fh, indent=2)
     os.replace(tmp, path)
 

--- a/bot_trade/tools/self_improver.py
+++ b/bot_trade/tools/self_improver.py
@@ -1,9 +1,13 @@
-import os
 import json
-import pandas as pd
+import os
 from collections import defaultdict
+from pathlib import Path
 
-KNOWLEDGE_FILE = "memory/knowledge_base.json"
+import pandas as pd
+
+from bot_trade.config.rl_paths import ensure_utf8, memory_dir
+
+KNOWLEDGE_FILE = memory_dir() / "knowledge_base.json"
 
 def load_performance_data(step_log_path="results/step_log.csv"):
     if not os.path.exists(step_log_path):
@@ -43,9 +47,8 @@ def extract_signal_stats(df):
     return wins, losses, signal_stats
 
 def update_knowledge_base(frame, symbol, win_signals, loss_signals, stats):
-    if os.path.exists(KNOWLEDGE_FILE):
-        with open(KNOWLEDGE_FILE, "r", encoding="utf-8") as f:
-            kb = json.load(f)
+    if KNOWLEDGE_FILE.exists():
+        kb = json.loads(KNOWLEDGE_FILE.read_text(encoding="utf-8"))
     else:
         kb = {}
 
@@ -60,7 +63,7 @@ def update_knowledge_base(frame, symbol, win_signals, loss_signals, stats):
 
     kb[key]["signal_stats"] = stats
 
-    with open(KNOWLEDGE_FILE, "w", encoding="utf-8") as f:
+    with ensure_utf8(KNOWLEDGE_FILE, csv_newline=False) as f:
         json.dump(kb, f, indent=2, ensure_ascii=False)
 
     print(f"[KNOWLEDGE ✅] Updated knowledge base for {key} with {len(stats)} signals.")


### PR DESCRIPTION
## Summary
- Centralize root detection and memory locations in `rl_paths`
- Migrate legacy `bot_trade/memory` data to `<ROOT>/memory` automatically
- Replace hardcoded memory paths with `rl_paths.memory_dir()` across tools

## Testing
- `python -m py_compile bot_trade/config/rl_paths.py`
- `python -m py_compile bot_trade/tools/knowledge_hub.py`
- `python -m py_compile bot_trade/tools/run_state.py`
- `python -m py_compile bot_trade/tools/session_learning_engine.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b2668a45b4832dbd658e80bc1c5022