### PR TITLE
Add resumable training memory management

### DIFF
--- a/bot_trade/config/rl_args.py
+++ b/bot_trade/config/rl_args.py
@@ -67,6 +67,8 @@ def parse_args():
     ap.add_argument("--seed", type=int, default=42)
     ap.add_argument("--checkpoint-every", type=int, default=200_000)
     ap.add_argument("--resume-auto", action="store_true")
+    ap.add_argument("--resume", nargs="?", const="latest", default=None,
+                    help="Resume from memory snapshot (optionally specify run_id)")
     ap.add_argument("--progress", action="store_true")
     ap.add_argument("--safe", action="store_true")
     ap.add_argument("--use-indicators", action="store_true")

--- a/bot_trade/config/rl_builders.py
+++ b/bot_trade/config/rl_builders.py
@@ -205,7 +205,7 @@ def build_ppo(args, vec_env, is_discrete: bool):
     return model
 
 
-def build_callbacks(paths, writers, args, update_manager=None):
+def build_callbacks(paths, writers, args, update_manager=None, run_id=None, risk_manager=None, dataset_info=None):
     from stable_baselines3.common.callbacks import CheckpointCallback, CallbackList
     from .rl_callbacks import (
         StepsAndRewardCallback,
@@ -226,6 +226,11 @@ def build_callbacks(paths, writers, args, update_manager=None):
         args.frame,
         args.symbol,
         every=int(getattr(args, "artifact_every_steps", 100_000)),
+        run_id=run_id or getattr(args, "run_id", None),
+        args=args,
+        writers=writers,
+        risk_manager=risk_manager,
+        dataset_info=dataset_info,
     )
 
     callbacks = [ckpt_cb, best_cb, step_cb, art_cb]


### PR DESCRIPTION
## Summary
- add memory v2 loader with migration and dataset validation
- snapshot full training/env/risk state and commit atomically
- support `--resume` flag and periodic snapshots during training

## Testing
- `python -m py_compile bot_trade/tools/memory_manager.py bot_trade/config/rl_args.py bot_trade/train_rl.py bot_trade/config/rl_builders.py bot_trade/config/rl_callbacks.py`


------
https://chatgpt.com/codex/tasks/task_b_68b26974e188832dadff1e2e159f439e