### PR TITLE
feat: centralize logging and throttle risk noise

### DIFF
--- a/bot_trade/config/risk_manager.py
+++ b/bot_trade/config/risk_manager.py
@@ -40,11 +40,12 @@ class RiskManager:
         self.loss_streak = 0
         self.max_drawdown = 0.0
 
-        self.risk_log_path = log_path or os.path.join("logs", "risk.log")
-        os.makedirs(os.path.dirname(self.risk_log_path), exist_ok=True)
-        with open(self.risk_log_path, "w", encoding="utf-8", newline="") as f:
-            writer = csv.writer(f)
-            writer.writerow(["reason", "risk_pct", "ema_reward", "drawdown", "freeze_mode"])
+        self.risk_log_path = log_path
+        if self.risk_log_path:
+            os.makedirs(os.path.dirname(self.risk_log_path), exist_ok=True)
+            with open(self.risk_log_path, "w", encoding="utf-8", newline="") as f:
+                writer = csv.writer(f)
+                writer.writerow(["reason", "risk_pct", "ema_reward", "drawdown", "freeze_mode"])
         self._last_multi_log = 0.0
 
     def log_risk_reason(self, reason: str):
@@ -52,20 +53,21 @@ class RiskManager:
         throttle = 0.0
         if reason == "Multiple entry signals active":
             level = logging.DEBUG
-            throttle = 30.0
+            throttle = 5.0
             now = time.time()
             if now - self._last_multi_log < throttle:
                 return
             self._last_multi_log = now
-        with open(self.risk_log_path, "a", encoding="utf-8", newline="") as f:
-            writer = csv.writer(f)
-            writer.writerow([
-                reason,
-                f"{self.current_risk:.4f}",
-                f"{self.ema_reward:.4f}",
-                f"{self.max_drawdown:.4f}",
-                str(self.freeze_mode)
-            ])
+        if self.risk_log_path:
+            with open(self.risk_log_path, "a", encoding="utf-8", newline="") as f:
+                writer = csv.writer(f)
+                writer.writerow([
+                    reason,
+                    f"{self.current_risk:.4f}",
+                    f"{self.ema_reward:.4f}",
+                    f"{self.max_drawdown:.4f}",
+                    str(self.freeze_mode)
+                ])
         self.logger.log(level, f"[RISK_LOG] {reason} | risk={self.current_risk:.3f}")
 
     def update(

--- a/bot_trade/config/rl_paths.py
+++ b/bot_trade/config/rl_paths.py
@@ -317,6 +317,7 @@ def get_paths(symbol: str, frame: str) -> dict:
         "jsonl_decisions": os.path.join(logs_dir, "entry_decisions.jsonl"),
         "benchmark_log": os.path.join(logs_dir, "benchmark.log"),
         "risk_log": os.path.join(logs_dir, "risk.log"),
+        "risk_csv": os.path.join(logs_dir, "risk.csv"),
         "report_dir": _mk(DEFAULT_RESULTS_DIR, "reports"),
         "perf_dir": _mk(DEFAULT_RESULTS_DIR, "performance"),
         "best_zip": os.path.join(agents_dir, "deep_rl_best.zip"),


### PR DESCRIPTION
## Summary
- centralize logging output under canonical results/<symbol>/<frame>/logs and support configurable console level
- add combined size/time rotating file handler with UTF-8 encoding and header preservation
- throttle RiskManager "Multiple entry signals active" messages and allow optional risk CSV path

## Testing
- `python -m py_compile bot_trade/config/log_setup.py bot_trade/config/risk_manager.py bot_trade/config/rl_paths.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68b26c0155a4832d8dc660fff8544254