### PR TITLE
feat: make RL checkpoints explicit and resume-safe

### DIFF
--- a/bot_trade/config/rl_args.py
+++ b/bot_trade/config/rl_args.py
@@ -67,6 +67,7 @@ def parse_args():
     ap.add_argument("--seed", type=int, default=42)
     ap.add_argument("--checkpoint-every", type=int, default=200_000)
     ap.add_argument("--resume-auto", action="store_true")
+    ap.add_argument("--resume-best", action="store_true", help="Resume from best checkpoint if available")
     ap.add_argument("--resume", nargs="?", const="latest", default=None,
                     help="Resume from memory snapshot (optionally specify run_id)")
     ap.add_argument("--progress", action="store_true")

--- a/bot_trade/config/rl_builders.py
+++ b/bot_trade/config/rl_builders.py
@@ -209,7 +209,6 @@ def build_callbacks(paths, writers, args, update_manager=None, run_id=None, risk
     from stable_baselines3.common.callbacks import CheckpointCallback, CallbackList
     from .rl_callbacks import (
         StepsAndRewardCallback,
-        BestCheckpointCallback,
         PeriodicArtifactsCallback,
     )
     ckpt_cb = CheckpointCallback(
@@ -217,7 +216,6 @@ def build_callbacks(paths, writers, args, update_manager=None, run_id=None, risk
         save_path=paths["agents"],
         name_prefix="checkpoint",
     )
-    best_cb = BestCheckpointCallback(paths, check_every=max(50_000, int(getattr(args, "n_steps", 2048))))
     step_cb = StepsAndRewardCallback(args.frame, args.symbol, writers, log_every=int(getattr(args, "log_every", 2_000)))
     art_cb = PeriodicArtifactsCallback(
         update_manager,
@@ -233,7 +231,7 @@ def build_callbacks(paths, writers, args, update_manager=None, run_id=None, risk
         dataset_info=dataset_info,
     )
 
-    callbacks = [ckpt_cb, best_cb, step_cb, art_cb]
+    callbacks = [ckpt_cb, step_cb, art_cb]
 
     try:
         from .rl_callbacks import BenchmarkCallback, StrictDataSanityCallback

--- a/bot_trade/config/rl_paths.py
+++ b/bot_trade/config/rl_paths.py
@@ -109,6 +109,24 @@ def agents_dir(symbol: str, frame: str) -> Path:
     return d
 
 
+def latest_agent(symbol: str, frame: str) -> Path:
+    """Return path to the latest agent checkpoint."""
+
+    return agents_dir(symbol, frame) / "deep_rl.zip"
+
+
+def best_agent(symbol: str, frame: str) -> Path:
+    """Return path to the best agent checkpoint."""
+
+    return agents_dir(symbol, frame) / "deep_rl_best.zip"
+
+
+def vecnorm_path(symbol: str, frame: str) -> Path:
+    """Return path to VecNormalize statistics."""
+
+    return agents_dir(symbol, frame) / "vecnorm.pkl"
+
+
 def results_dir(symbol: str, frame: str) -> Path:
     d = get_root() / "results" / symbol.upper() / str(frame)
     d.mkdir(parents=True, exist_ok=True)
@@ -328,6 +346,9 @@ __all__ = [
     "get_root",
     "memory_dir",
     "agents_dir",
+    "latest_agent",
+    "best_agent",
+    "vecnorm_path",
     "results_dir",
     "reports_dir",
     "logs_dir",


### PR DESCRIPTION
## Summary
- add helpers for latest/best agents and VecNormalize stats
- save latest model on each evaluation and promote best with metadata
- support `--resume-best` flag and load matching VecNormalize stats

## Testing
- `python -m py_compile bot_trade/config/rl_paths.py bot_trade/config/rl_args.py bot_trade/config/rl_builders.py bot_trade/train_rl.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b26e797c10832db9a8d901736b42b0