### PR TITLE
Improve RL training device handling and monitor integration

### DIFF
--- a/bot_trade/config/device.py
+++ b/bot_trade/config/device.py
@@ -1,33 +1,33 @@
-def normalize_device(arg: str | None) -> str | None:
-    """Normalize device input to 'cpu' or 'cuda:<idx>'.
+"""Device normalization utilities."""
+from __future__ import annotations
+from typing import Optional, Dict
 
-    Parameters
-    ----------
-    arg: str | None
-        Device specification from CLI. Accepted values:
-        - None -> auto-select later
-        - 'cpu' -> 'cpu'
-        - 'cuda' -> 'cuda:0'
-        - 'cuda:<n>' -> 'cuda:<n>'
-        - '<int>' -> 'cuda:<int>' if >= 0 else 'cpu'
-        - '-1' -> 'cpu'
-    Returns
-    -------
-    str | None
-        Normalized device string or None for auto-selection.
+def normalize_device(arg: str | None, env: Dict[str, str]) -> str | None:
+    """Normalize device input to 'cpu', 'cuda:<idx>' or None for auto.
+
+    Rules:
+      - If env['CUDA_VISIBLE_DEVICES'] exists and is '' (empty string), force 'cpu'.
+      - arg in {'cpu', 'CUDA', 'cuda'} -> 'cpu' or 'cuda:0' respectively.
+      - 'cuda:<n>' stays as is if n is digit.
+      - '<int>' -> 'cuda:<int>' if >=0 else 'cpu'
+      - '-1' -> 'cpu'
+      - None -> defer to auto after importing torch.
     """
+    if env.get('CUDA_VISIBLE_DEVICES', None) == '':
+        return 'cpu'
     if arg is None:
         return None
     s = str(arg).strip()
     if not s:
         return None
     low = s.lower()
-    if low == 'cpu' or low == '-1':
+    if low in {'cpu', '-1'}:
         return 'cpu'
-    if low == 'cuda':
+    if low in {'cuda', 'gpu'}:
         return 'cuda:0'
     if low.startswith('cuda:'):
-        return f"cuda:{low.split(':', 1)[1]}"
+        idx = low.split(':', 1)[1]
+        return f'cuda:{idx}' if idx.isdigit() else 'cuda:0'
     try:
         idx = int(low)
         return 'cpu' if idx < 0 else f'cuda:{idx}'

--- a/bot_trade/tools/monitor_manager.py
+++ b/bot_trade/tools/monitor_manager.py
@@ -172,7 +172,7 @@ def main(argv: List[str] | None = None) -> None:
         if img_dir:
             msg += f" images->{img_dir}"
         print(msg, flush=True)
-        return
+        sys.exit(0)
 
     from bot_trade.tools.analytics_common import wait_for_first_write
     from bot_trade.tools.monitor_launch import launch_new_console


### PR DESCRIPTION
## Summary
- add math import and cosine LR schedule fix
- respect user-specified n_envs and improve auto-scaling logs
- support robust device parsing, lazy torch import, and detached headless monitor

## Testing
- `python -m pip install -e .`
- `python -m bot_trade.train_rl --help`
- `python -m bot_trade.tools.monitor_manager --help`
- `CUDA_VISIBLE_DEVICES="" python -m bot_trade.train_rl --symbol BTCUSDT --frame 1m --n-envs 1 --total-steps 1000 --artifact-every-steps 500 --log-level INFO` *(fails: No data files found for symbol='BTCUSDT' frame='1m' in /workspace/bot-trade/data_ready/1m)*
- `python -m bot_trade.train_rl --symbol BTCUSDT --frame 1m --device 0 --n-envs 1 --total-steps 1000` *(fails: No data files found for symbol='BTCUSDT' frame='1m' in /workspace/bot-trade/data_ready/1m)*

------
https://chatgpt.com/codex/tasks/task_b_68b28f05519c832d8393e4efb302acb5