### PR TITLE
Guard monitor process handle and throttle risk logs

### DIFF
--- a/bot_trade/tools/monitor_manager.py
+++ b/bot_trade/tools/monitor_manager.py
@@ -173,7 +173,7 @@ def main(argv: List[str] | None = None) -> None:
             msg += f" images->{img_dir}"
         print(msg, flush=True)
         print("Headless refresh done.", flush=True)
-        sys.exit(0)
+        return 0
 
     from bot_trade.tools.analytics_common import wait_for_first_write
     from bot_trade.tools.monitor_launch import launch_new_console
@@ -262,5 +262,5 @@ def main(argv: List[str] | None = None) -> None:
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())
 


### PR DESCRIPTION
## Summary
- Add headless/interactive switch to `_spawn_monitor` and guard monitor process handling in training to avoid undefined references.
- Ensure monitor manager in `--no-wait` mode performs one pass and exits immediately.
- Downgrade and rate-limit repetitive risk logging to reduce noise.

## Testing
- `python -m py_compile bot_trade/**/*.py`
- `CUDA_VISIBLE_DEVICES="" python -m bot_trade.train_rl --symbol BTCUSDT --frame 1m --device cpu --n-envs 1 --total-steps 1000 --artifact-every-steps 500 --log-level INFO`
- `python -m bot_trade.tools.monitor_manager --symbol BTCUSDT --frame 1m --base . --no-wait --run-id test`


------
https://chatgpt.com/codex/tasks/task_b_68b29cc2fb50832da562cb9b43f8dbbf