### PR TITLE
Add reward logging, memory snapshots, and headless chart export

### DIFF
--- a/bot_trade/tools/runctx.py
+++ b/bot_trade/tools/runctx.py
@@ -29,9 +29,16 @@ def _git_hash() -> str:
 
 
 def new_run_id(symbol: str, frame: str) -> str:
-    ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H-%M-%SZ")
-    gh = _git_hash()[:7]
-    return f"{symbol}-{frame}-{ts}-{gh}"
+    """Return a session-stable run identifier.
+
+    Format: ``run-<SYMBOL>-<FRAME>-<YYYYMMDD_HHMMSS>-<shortid>``.
+    ``shortid`` is the first 4 hex chars of the current git hash or ``nogit``.
+
+    # TODO: consider allowing custom run id prefix/suffix via CLI.
+    """
+    ts = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    gh = _git_hash()[:4]
+    return f"run-{symbol}-{frame}-{ts}-{gh}"
 
 
 def run_paths(symbol: str, frame: str, run_id: str) -> Dict[str, Path]:


### PR DESCRIPTION
## Summary
- capture per-step rewards with run-aware `reward.log`
- write periodic training snapshots and restore VecNormalize state on resume
- render monitoring charts non-interactively in headless mode

## Testing
- `python -m py_compile bot_trade/config/rl_writers.py bot_trade/config/rl_callbacks.py bot_trade/config/update_manager.py bot_trade/train_rl.py bot_trade/tools/memory_manager.py bot_trade/tools/monitor_manager.py bot_trade/tools/analytics_common.py bot_trade/config/log_setup.py`
- `pytest`
- `python -m bot_trade.train_rl --symbol BTCUSDT --frame 1m --total-steps 2000 --n-envs 2 --device cpu --resume-auto` *(fails: No data files found)*
- `python -m bot_trade.tools.monitor_manager --symbol BTCUSDT --frame 1m --no-wait --headless --run-id fake`


------
https://chatgpt.com/codex/tasks/task_b_68b361b67878832d9fb23bf76df9618b