### PR TITLE
Ensure charts exported before postrun summary and auto vecnorm on resume

### DIFF
--- a/bot_trade/train_rl.py
+++ b/bot_trade/train_rl.py
@@ -26,6 +26,7 @@ logger = logging.getLogger(__name__)
 from bot_trade.config.rl_paths import dataset_path, RunPaths, ensure_contract
 from bot_trade.config.device import normalize_device
 from bot_trade.config.rl_callbacks import _save_vecnorm
+from bot_trade.tools.monitor_manager import export_charts_for_run
 
 # Heavy dependencies (torch, numpy, pandas, stable_baselines3, etc.) are
 # imported inside `main` to keep import-time side effects minimal and to
@@ -254,19 +255,32 @@ def _logging_monitor_loop(queue, listener):
 
 def _postrun_summary(paths, meta, logger):
     from pathlib import Path
-    run_id = meta.get("run_id") or (paths.get("run_id") if isinstance(paths, dict) else getattr(paths, "run_id", "<unknown>"))
+    run_id = meta.get("run_id") or (
+        paths.get("run_id") if isinstance(paths, dict) else getattr(paths, "run_id", "<unknown>")
+    )
     sym = getattr(paths, "symbol", meta.get("symbol", "?"))
     frm = getattr(paths, "frame", meta.get("frame", "?"))
-    charts_dir_base = Path(paths["reports"]) if isinstance(paths, dict) else paths.reports
-    charts_dir = charts_dir_base / "charts"
+
     reward_path_base = Path(paths["results"]) if isinstance(paths, dict) else paths.results
     reward_path = reward_path_base / "reward" / "reward.log"
     agents_base = Path(paths["agents_root"]) if isinstance(paths, dict) else paths.agents_root
     best = agents_base / "deep_rl_best.zip"
     last = agents_base / "deep_rl_last.zip"
     vecnorm = (paths.get("vecnorm") if isinstance(paths, dict) else getattr(paths, "vecnorm", None))
-    pngs = list(charts_dir.glob("*.png")) if charts_dir.exists() else []
-    images = len(pngs)
+
+    try:
+        charts_dir, images = export_charts_for_run(
+            symbol=sym,
+            frame=frm,
+            run_id=run_id,
+            base=str(Path.cwd()),
+            headless=True,
+        )
+        logger.info("[POSTRUN_EXPORT] charts=%s images=%d", charts_dir, images)
+    except Exception as e:
+        charts_dir, images = ((Path(paths["reports"]) if isinstance(paths, dict) else paths.reports) / "charts").resolve(), 0
+        logger.warning("[POSTRUN_EXPORT] export_failed err=%s", e)
+
     reward_lines = 0
     if reward_path.exists():
         with reward_path.open("r", encoding="utf-8", errors="ignore") as fh:
@@ -597,6 +611,14 @@ def train_one_file(args, data_file: str) -> bool:
             pass
 
     # 6) Load VecNormalize statistics
+    if getattr(args, "resume_auto", False):
+        try:
+            from pathlib import Path
+            vec_path = paths["vecnorm"] if isinstance(paths, dict) else getattr(paths, "vecnorm", None)
+            if vec_path and Path(vec_path).exists():
+                args.vecnorm = True
+        except Exception:
+            pass
     vec_env, vecnorm_applied = _try_apply_vecnorm(vec_env, args, paths, logging)
     vecnorm_ref = vec_env if getattr(args, "vecnorm", False) else None
     run_meta["vecnorm_applied"] = vecnorm_applied


### PR DESCRIPTION
## Summary
- Chart exporter waits for reward data, uses Agg backend, and returns only real PNG count, skipping symlinks
- `monitor_manager --run-id latest` now ignores symlinked runs and `train_rl` logs chart exports with the actual image tally
- Resuming training auto-enables VecNormalize when a saved snapshot is found

## Testing
- `python -m py_compile bot_trade/tools/monitor_manager.py bot_trade/train_rl.py`
- `pytest -q`
- `python -m bot_trade.train_rl --symbol BTCUSDT --frame 1m --total-steps 2000 --n-envs 2 --device cpu --vecnorm --headless --data-root data_ready` *(fails: missing dataset)*
- `python -m bot_trade.tools.monitor_manager --symbol BTCUSDT --frame 1m --headless` *(fails: could not determine run_id)*
- `python -m bot_trade.train_rl --symbol BTCUSDT --frame 1m --total-steps 1000 --n-envs 2 --device cpu --resume-auto --headless --data-root data_ready` *(fails: missing dataset)*

------
https://chatgpt.com/codex/tasks/task_b_68b3ec03bfe4832da8d191cb00cef4ba