### PR TITLE
feat: add dual archive for RL models

### DIFF
--- a/CHANGE_NOTES.md
+++ b/CHANGE_NOTES.md
@@ -42,3 +42,4 @@ Template:
 - **Rationale**: generate real headless charts without placeholders and ensure risk flag exports via `risk_log.csv`.
 - **Risks**: chart generation still depends on log availability.
 - **Test Steps**: `python -m py_compile bot_trade/config/*.py bot_trade/tools/*.py`, `pytest -q || echo "no tests found"`, `python -m bot_trade.tools.monitor_manager --symbol BTCUSDT --frame 1m --headless`
+2025-09-03 — Dual-archive model lifecycle: previous BEST models now moved to agents/<S>/<F>/archive_best/ (stamped filenames + optional vecnorm_best snapshot + index.csv). Non-best artifacts remain under archive/. Atomic promotions; best_meta.json updated.

--- a/tools/migrate_artifacts.py
+++ b/tools/migrate_artifacts.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+"""Migrate legacy model artifacts to new dual-archive layout."""
+from __future__ import annotations
+
+import argparse
+import csv
+import shutil
+import datetime as dt
+from pathlib import Path
+
+from bot_trade.config.rl_paths import get_root
+
+
+def migrate(symbol: str, frame: str) -> None:
+    root = get_root()
+    agents = root / "agents" / symbol.upper() / str(frame)
+    archive = agents / "archive"
+    archive_best = agents / "archive_best"
+    archive_best.mkdir(parents=True, exist_ok=True)
+    index = archive_best / "index.csv"
+    idx_exists = index.exists()
+    idx_fh = index.open("a", encoding="utf-8", newline="")
+    writer = csv.writer(idx_fh)
+    if not idx_exists:
+        writer.writerow(["ts", "run_id", "metric", "model_path", "vecnorm_path"])
+    moved: list[tuple[str, str]] = []
+    for file in archive.glob("deep_rl_best-*.zip"):
+        dst = archive_best / file.name
+        shutil.move(str(file), dst)
+        writer.writerow([dt.datetime.utcnow().strftime("%Y%m%d-%H%M%S"), "legacy", "", str(dst), ""])
+        moved.append((str(file), str(dst)))
+    idx_fh.close()
+    if moved:
+        report_dir = root / "reports"
+        report_dir.mkdir(parents=True, exist_ok=True)
+        report = report_dir / f"migration_{dt.datetime.utcnow().strftime('%Y%m%d-%H%M%S')}.csv"
+        with report.open("w", encoding="utf-8", newline="") as fh:
+            w = csv.writer(fh)
+            w.writerow(["src", "dst"])
+            w.writerows(moved)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--symbol", required=True)
+    ap.add_argument("--frame", required=True)
+    args = ap.parse_args()
+    migrate(args.symbol, args.frame)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- track best and last models with dual-archive paths
- archive previous best models and vecnorm snapshots with metadata
- provide migration helper for legacy artifacts

## Testing
- `python -m py_compile bot_trade/config/*.py bot_trade/tools/*.py bot_trade/train_rl.py tools/migrate_artifacts.py`
- `python -m bot_trade.train_rl --symbol BTCUSDT --frame 1m --total-steps 3000 --n-envs 2 --device cpu --vecnorm --headless --data-dir data_ready` *(fails: [NO DATA])*

------
https://chatgpt.com/codex/tasks/task_b_68b4a981a35c832d945893d5cac3ec00