### PR TITLE
Robust post-run chart export with fallback images

### DIFF
--- a/bot_trade/train_rl.py
+++ b/bot_trade/train_rl.py
@@ -277,13 +277,8 @@ def _postrun_summary(paths, meta):
     frm = getattr(paths, "frame", meta.get("frame", "?"))
 
     try:
-        charts_dir, img_count = export_charts_for_run(
-            symbol=sym,
-            frame=frm,
-            run_id=str(paths["run_id"]) if isinstance(paths, dict) else getattr(paths, "run_id"),
-            base=str(pathlib.Path.cwd()),
-            headless=True,
-        )
+        rp = paths if isinstance(paths, RunPaths) else RunPaths(sym, frm, str(run_id))
+        charts_dir, img_count = export_charts_for_run(rp)
         logger.info("[POSTRUN_EXPORT] charts=%s images=%d", charts_dir, img_count)
     except Exception as e:
         charts_dir = (pathlib.Path(paths["reports"]) / "charts").resolve() if isinstance(paths, dict) else (paths.reports / "charts").resolve()
@@ -292,7 +287,7 @@ def _postrun_summary(paths, meta):
 
     reward_path_base = pathlib.Path(paths["results"]) if isinstance(paths, dict) else paths.results
     reward_path = reward_path_base / "reward" / "reward.log"
-    agents_base = pathlib.Path(paths["agents_root"]) if isinstance(paths, dict) else paths.agents_root
+    agents_base = pathlib.Path(paths["agents_root"]) if isinstance(paths, dict) else paths.agents
     best = agents_base / "deep_rl_best.zip"
     last = agents_base / "deep_rl_last.zip"
     vecnorm = (paths.get("vecnorm") if isinstance(paths, dict) else getattr(paths, "vecnorm", None))


### PR DESCRIPTION
## Summary
- Normalize reward columns and force Agg backend for chart exports while returning PNG counts
- Add synchronous chart exporter with fallback plotting and minimum image guarantees
- Integrate chart export into post-run summary and adjust agent path handling

## Testing
- `python -m py_compile bot_trade/tools/export_charts.py bot_trade/tools/monitor_manager.py bot_trade/train_rl.py`
- `python -m bot_trade.tools.monitor_manager --symbol BTCUSDT --frame 1m --run-id demo --headless`
- `python - <<'PY'
from bot_trade.config.rl_paths import RunPaths
from bot_trade.train_rl import _postrun_summary
rp=RunPaths('BTCUSDT','1m','testrun2')
(rp.results/'reward').mkdir(parents=True, exist_ok=True)
(rp.results/'reward'/'reward.log').write_text('1\n2\n3')
(rp.logs).mkdir(parents=True, exist_ok=True)
(rp.logs/'step_log.csv').write_text('1\n2')
_postrun_summary(rp, {'run_id':'testrun2','symbol':'BTCUSDT','frame':'1m'})
PY`

------
https://chatgpt.com/codex/tasks/task_b_68b4d2126f08832db15109b40285215d