### PR TITLE
Add robust chart exporter and KB logging

### DIFF
--- a/bot_trade/config/rl_args.py
+++ b/bot_trade/config/rl_args.py
@@ -43,7 +43,10 @@ def build_policy_kwargs(net_arch_str: str, activation: str, ortho_init: bool) ->
     return kw
 
 def parse_args():
-    ap = argparse.ArgumentParser("train_rl — orchestrator")
+    ap = argparse.ArgumentParser(
+        description="Train reinforcement learning agent",
+        epilog="Example: python -m bot_trade.train_rl --symbol BTCUSDT --frame 1m",
+    )
     ap.add_argument("--symbol", type=str, default="BTCUSDT")
     ap.add_argument("--frame", type=str, default="1m")
     ap.add_argument("--policy", type=str, default="MlpPolicy")

--- a/bot_trade/config/rl_paths.py
+++ b/bot_trade/config/rl_paths.py
@@ -416,7 +416,7 @@ DEFAULT_MEMORY_FILE = os.environ.get(
     "BOT_MEMORY_FILE", str(memory_dir() / "memory.json")
 )
 DEFAULT_KB_FILE = os.environ.get(
-    "BOT_KB_FILE", str(memory_dir() / "knowledge_base_full.json")
+    "BOT_KB_FILE", str(memory_dir() / "Knowlogy" / "kb.jsonl")
 )
 
 

--- a/bot_trade/config/update_manager.py
+++ b/bot_trade/config/update_manager.py
@@ -88,7 +88,7 @@ class UpdateManager:
         # ------------------------------------------------------------------
         # Knowledge aggregation
         self._knowledge_events = os.path.join(self.logs_dir, "knowledge_events.jsonl")
-        self._kb_full = paths.get("kb_file") or str(memory_dir() / "knowledge_base_full.json")
+        self._kb_full = paths.get("kb_file") or str(memory_dir() / "Knowlogy" / "kb.jsonl")
 
     # ------------------------------------------------------------------
     # API methods

--- a/bot_trade/tools/gen_synth_data.py
+++ b/bot_trade/tools/gen_synth_data.py
@@ -32,10 +32,13 @@ def generate(symbol: str, frame: str, out_dir: Path) -> Path:
 
 
 def main(argv: list[str] | None = None) -> int:
-    ap = argparse.ArgumentParser("generate synthetic dataset")
-    ap.add_argument("--symbol", default="BTCUSDT")
-    ap.add_argument("--frame", default="1m")
-    ap.add_argument("--out", default="data_ready")
+    ap = argparse.ArgumentParser(
+        description="Generate synthetic OHLCV data for development",
+        epilog="Example: python -m bot_trade.tools.gen_synth_data --symbol BTCUSDT --frame 1m --out data_ready",
+    )
+    ap.add_argument("--symbol", default="BTCUSDT", help="Trading symbol")
+    ap.add_argument("--frame", default="1m", help="Time frame")
+    ap.add_argument("--out", default="data_ready", help="Output data directory")
     ns = ap.parse_args(argv)
 
     dest = generate(ns.symbol, ns.frame, Path(ns.out))

--- a/bot_trade/tools/monitor_manager.py
+++ b/bot_trade/tools/monitor_manager.py
@@ -1,9 +1,4 @@
-"""CLI wrapper around :func:`export_for_run`.
-
-The monitor manager is a light utility that discovers the latest run and
-invokes the exporter.  It is primarily used during development to verify
-that logs are written correctly.
-"""
+"""Run monitor/exporter for training charts."""
 
 from __future__ import annotations
 
@@ -11,8 +6,12 @@ import argparse
 import sys
 from pathlib import Path
 
+import matplotlib
+
+matplotlib.use("Agg")
+
 from bot_trade.config.rl_paths import RunPaths, get_root
-from bot_trade.tools.export_charts import export_for_run
+from bot_trade.tools.export_charts import export_run_charts
 
 
 def _latest_run(symbol: str, frame: str, reports_root: Path) -> str | None:
@@ -27,13 +26,16 @@ def _latest_run(symbol: str, frame: str, reports_root: Path) -> str | None:
 
 
 def main(argv: list[str] | None = None) -> int:
-    ap = argparse.ArgumentParser("monitor manager")
-    ap.add_argument("--symbol", default="BTCUSDT")
-    ap.add_argument("--frame", default="1m")
-    ap.add_argument("--run-id", default="latest")
-    ap.add_argument("--base", default=None)
-    ap.add_argument("--debug-export", action="store_true")
-    ap.add_argument("--headless", action="store_true", help="no-op for compatibility")
+    ap = argparse.ArgumentParser(
+        description="Generate charts for a finished training run",
+        epilog="Example: python -m bot_trade.tools.monitor_manager --symbol BTCUSDT --frame 1m --run-id latest",
+    )
+    ap.add_argument("--symbol", default="BTCUSDT", help="Trading symbol")
+    ap.add_argument("--frame", default="1m", help="Time frame")
+    ap.add_argument("--run-id", default="latest", help="Run identifier or 'latest'")
+    ap.add_argument("--data-dir", default=None, help="Optional dataset directory (unused)")
+    ap.add_argument("--base", default=None, help="Project root override")
+    ap.add_argument("--debug-export", action="store_true", help="Print diagnostic information")
     ns = ap.parse_args(argv)
 
     try:
@@ -46,22 +48,20 @@ def main(argv: list[str] | None = None) -> int:
             print("[ERROR] run not found", file=sys.stderr)
             return 2
         rp = RunPaths(ns.symbol, ns.frame, run_id, root=root)
-        info = export_for_run(rp, debug=ns.debug_export)
-        rows = info.get("rows", {})
+        charts_dir, images, rows = export_run_charts(rp, run_id, debug=ns.debug_export)
         if ns.debug_export:
             print(
-                "[DEBUG_EXPORT] reward_rows=%d step_rows=%d train_rows=%d risk_rows=%d callbacks_rows=%d signals_rows=%d"
+                "[DEBUG_EXPORT] reward_rows=%d step_rows=%d train_rows=%d risk_rows=%d signals_rows=%d"
                 % (
                     rows.get("reward", 0),
                     rows.get("step", 0),
                     rows.get("train", 0),
                     rows.get("risk", 0),
-                    rows.get("callbacks", 0),
                     rows.get("signals", 0),
                 )
             )
-        print(f"[CHARTS] dir={info['charts_dir']} images={info['images']}")
-        return 0 if info["images"] > 0 else 2
+        print(f"[CHARTS] dir={charts_dir} images={images}")
+        return 0 if images > 0 else 2
     except Exception as exc:  # pragma: no cover
         print(f"[ERROR] {exc}", file=sys.stderr)
         return 1


### PR DESCRIPTION
## Summary
- add `export_run_charts` utility generating placeholder images and reading logs safely
- update monitor manager and CLI helpers to use new exporter and Agg backend
- persist portfolio state and append Knowlogy KB entries after training

## Testing
- `python -m py_compile bot-trade/bot_trade/config/*.py bot-trade/bot_trade/tools/*.py bot-trade/bot_trade/train_rl.py`
- `python -m bot_trade.tools.gen_synth_data --symbol BTCUSDT --frame 1m --out data_ready`
- `python -m bot_trade.train_rl   --symbol BTCUSDT --frame 1m   --policy MlpPolicy --device cpu   --n-envs 2 --n-steps 512 --batch-size 1024 --epochs 5   --total-steps 2048   --net-arch "1024,512,256" --activation silu   --vecnorm --allow-synth --data-dir data_ready`
- `python -m bot_trade.tools.monitor_manager --symbol BTCUSDT --frame 1m --run-id latest --debug-export`
- `python - <<'PY'
from pathlib import Path
p = Path("reports/BTCUSDT/1m")
rid = sorted([d for d in p.iterdir() if d.is_dir()], key=lambda d: d.stat().st_mtime)[-1].name
charts = Path(f"reports/BTCUSDT/1m/{rid}/charts")
perf   = Path(f"reports/BTCUSDT/1m/{rid}/performance/portfolio_state.json")
kb     = Path("memory/Knowlogy/kb.jsonl")
print("[ASSERT charts>=5]", len(list(charts.glob("*.png"))) >= 5)
print("[ASSERT perf exists]", perf.exists())
print("[ASSERT kb exists]", kb.exists())
PY`


------
https://chatgpt.com/codex/tasks/task_b_68b5319db08c832dbcd5157994245f34