### PR TITLE
Centralize Knowlogy KB writes and enrich run records

### DIFF
--- a/CHANGE_NOTES.md
+++ b/CHANGE_NOTES.md
@@ -51,3 +51,15 @@ Template:
 - **Rationale**: reports now ingest reward/step/train/risk/callbacks/signals with ≥5 charts, automatic evaluation and summary export, knowledge base JSONL updates, synthetic data generator for dev, and refreshed CLI defaults.
 - **Risks**: synthetic evaluation is simplistic; chart placeholders may hide data issues.
 - **Test Steps**: `python -m py_compile bot_trade/config/*.py bot_trade/tools/*.py bot_trade/train_rl.py`; run smoke `python -m bot_trade.tools.gen_synth_data --symbol BTCUSDT --frame 1m --out data_ready`, `python -m bot_trade.train_rl --symbol BTCUSDT --frame 1m --policy MlpPolicy --device cpu --n-envs 2 --n-steps 512 --batch-size 1024 --total-steps 2048 --net-arch "1024,512,256" --activation silu --vecnorm --headless --allow-synth --kb-file Knowlogy/kb.jsonl --data-dir data_ready`, then `python -m bot_trade.tools.monitor_manager --symbol BTCUSDT --frame 1m --run-id latest --debug-export`.
+
+## 2025-09-20
+- **Files**: `bot_trade/tools/kb_writer.py`, `bot_trade/train_rl.py`, `CHANGE_NOTES.md`
+- **Rationale**: centralize knowledge base writes with canonical path and richer run metadata.
+- **Risks**: KB file may grow large; portfolio metrics depend on state availability.
+- **Test Steps**: `python -m py_compile bot_trade/config/*.py bot_trade/tools/*.py bot_trade/train_rl.py`, `python - <<'PY'
+from bot_trade.config.rl_paths import RunPaths
+from bot_trade.tools.kb_writer import kb_append
+rp = RunPaths('BTCUSDT','1m','testrun')
+kb_append(rp, {"run_id":"testrun","symbol":"BTCUSDT","frame":"1m","ts":"0","images":0,"rows_reward":0,"rows_step":0,"rows_train":0,"rows_risk":0,"rows_signals":0,"vecnorm_applied":False,"vecnorm_snapshot_saved":False,"best":False,"last":False,"best_model_path":"/tmp","eval":{},"portfolio":{},"notes":""})
+print('KB', rp.kb_file)
+PY`

--- a/bot_trade/tools/kb_writer.py
+++ b/bot_trade/tools/kb_writer.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+"""Utility for appending run metadata to the knowledge base.
+
+This module centralizes writes to the Knowlogy knowledge base. Entries are
+stored in JSON Lines format with one JSON object per line.  Writes are
+performed atomically to avoid corrupting the file.
+"""
+
+from pathlib import Path
+import json
+import os
+from typing import Any, Mapping
+
+from bot_trade.config.rl_paths import DEFAULT_KB_FILE
+
+
+def _resolve_kb_path(run_paths: Any) -> Path:
+    """Return KB path from a RunPaths instance or mapping.
+
+    Falls back to the canonical location when ``kb_file`` is missing.
+    """
+
+    if isinstance(run_paths, (str, Path)):
+        return Path(run_paths)
+    if isinstance(run_paths, Mapping):
+        kb = run_paths.get("kb_file")
+        if kb:
+            return Path(kb)
+    kb = getattr(run_paths, "kb_file", None)
+    if kb:
+        return Path(kb)
+    return Path(DEFAULT_KB_FILE)
+
+
+def kb_append(run_paths: Any, payload: dict) -> None:
+    """Atomically append ``payload`` to the knowledge base.
+
+    Parameters
+    ----------
+    run_paths:
+        RunPaths instance, mapping, or path-like pointing to the KB file.
+    payload:
+        Dictionary payload to serialize as JSON.
+    """
+
+    path = _resolve_kb_path(run_paths)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    existing = ""
+    if path.exists():
+        try:
+            existing = path.read_text(encoding="utf-8")
+        except Exception:
+            existing = ""
+
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    with tmp.open("w", encoding="utf-8", newline="\n") as fh:
+        if existing:
+            fh.write(existing.rstrip("\n") + "\n")
+        fh.write(json.dumps(payload, ensure_ascii=False) + "\n")
+    os.replace(tmp, path)


### PR DESCRIPTION
## Summary
- add kb_writer module for atomic JSONL appends to canonical Knowlogy path
- log richer run metadata and call kb_append after training

## Testing
- `python -m py_compile bot_trade/config/*.py bot_trade/tools/*.py bot_trade/train_rl.py`
- `python - <<'PY'
from bot_trade.config.rl_paths import RunPaths
from bot_trade.tools.kb_writer import kb_append
rp = RunPaths('BTCUSDT','1m','testrun')
kb_append(rp, {"run_id":"testrun","symbol":"BTCUSDT","frame":"1m","ts":"0","images":0,"rows_reward":0,"rows_step":0,"rows_train":0,"rows_risk":0,"rows_signals":0,"vecnorm_applied":False,"vecnorm_snapshot_saved":False,"best":False,"last":False,"best_model_path":"/tmp","eval":{},"portfolio":{},"notes":""})
print('KB path:', rp.kb_file)
print('KB file exists?', rp.kb_file.exists())
PY`


------
https://chatgpt.com/codex/tasks/task_b_68b5428f0108832d9d2f01d91e3ad528