### PR TITLE
Polish CLI help and ensure atomic artifacts

### DIFF
--- a/bot_trade/config/rl_args.py
+++ b/bot_trade/config/rl_args.py
@@ -45,7 +45,10 @@ def build_policy_kwargs(net_arch_str: str, activation: str, ortho_init: bool) ->
 def parse_args():
     ap = argparse.ArgumentParser(
         description="Train reinforcement learning agent",
-        epilog="Example: python -m bot_trade.train_rl --symbol BTCUSDT --frame 1m",
+        epilog=(
+            "Example: python -m bot_trade.train_rl "
+            "--symbol BTCUSDT --frame 1m --allow-synth"
+        ),
     )
     ap.add_argument("--symbol", type=str, default="BTCUSDT")
     ap.add_argument("--frame", type=str, default="1m")

--- a/bot_trade/tools/gen_synth_data.py
+++ b/bot_trade/tools/gen_synth_data.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import os
 from pathlib import Path
 
 import numpy as np
@@ -27,7 +28,9 @@ def generate(symbol: str, frame: str, out_dir: Path) -> Path:
     sub = out_dir / frame
     sub.mkdir(parents=True, exist_ok=True)
     dest = sub / f"{symbol}-{frame}-synth.feather"
-    df.to_feather(dest)
+    tmp = dest.with_suffix(dest.suffix + ".tmp")
+    df.to_feather(tmp)
+    os.replace(tmp, dest)
     return dest
 
 

--- a/bot_trade/tools/monitor_manager.py
+++ b/bot_trade/tools/monitor_manager.py
@@ -28,7 +28,10 @@ def _latest_run(symbol: str, frame: str, reports_root: Path) -> str | None:
 def main(argv: list[str] | None = None) -> int:
     ap = argparse.ArgumentParser(
         description="Generate charts for a finished training run",
-        epilog="Example: python -m bot_trade.tools.monitor_manager --symbol BTCUSDT --frame 1m --run-id latest",
+        epilog=(
+            "Example: python -m bot_trade.tools.monitor_manager "
+            "--symbol BTCUSDT --frame 1m --run-id latest --debug-export"
+        ),
     )
     ap.add_argument("--symbol", default="BTCUSDT", help="Trading symbol")
     ap.add_argument("--frame", default="1m", help="Time frame")


### PR DESCRIPTION
## Summary
- expand CLI help examples across training, monitoring, chart export, evaluation, and synthetic data generation
- export charts and evaluation plots using atomic writes; provide new `export_run_charts` CLI
- ensure default KB path and standardized POSTRUN summary metrics in RL training

## Testing
- `python -m py_compile bot_trade/config/rl_args.py bot_trade/tools/monitor_manager.py bot_trade/tools/export_run_charts.py bot_trade/tools/eval_run.py bot_trade/tools/gen_synth_data.py bot_trade/train_rl.py`
- `pytest -q`
- `python -m bot_trade.train_rl --help | tail -n 5`
- `python -m bot_trade.tools.monitor_manager --help | tail -n 5`
- `python -m bot_trade.tools.export_run_charts --help | tail -n 5`
- `python -m bot_trade.tools.eval_run --help | tail -n 5`
- `python -m bot_trade.tools.gen_synth_data --help | tail -n 5`


------
https://chatgpt.com/codex/tasks/task_b_68b55330cf88832d88c4e777e64fe8fb