### PR TITLE
Standardize headless chart exports and eval CLI

### DIFF
--- a/CHANGE_NOTES.md
+++ b/CHANGE_NOTES.md
@@ -100,3 +100,9 @@ PY`
 - Legacy flags like `--no-wait` and `--debug-export` remain accepted but are no-ops.
 - Risks/Migration: tools now emit extra lines; parsers expecting silence must adapt. KB records include `rows_callbacks` and may change ordering.
 - Next: track KB size growth, richer eval metrics, and automation around smoke tests.
+
+## 2025-09-24
+- **Files**: `bot_trade/tools/export_run_charts.py`, `bot_trade/tools/monitor_manager.py`, `bot_trade/tools/eval_run.py`, `bot_trade/train_rl.py`, `DEV_NOTES.md`, `CHANGE_NOTES.md`
+- **Rationale**: finalize Delta Pack with standardized debug/charts lines, headless notices, atomic PNG params, and non-silent eval.
+- **Risks**: scripts parsing old outputs may need updates; additional prints could affect log consumers.
+- **Test Steps**: `python -m py_compile bot_trade/config/*.py bot_trade/tools/*.py bot_trade/train_rl.py`; `python -m bot_trade.tools.monitor_manager --help`; `python -m bot_trade.tools.export_run_charts --help`; `python -m bot_trade.tools.eval_run --help`; run synthetic training and verify [DEBUG_EXPORT]/[CHARTS]/[EVAL] lines.

--- a/DEV_NOTES.md
+++ b/DEV_NOTES.md
@@ -59,3 +59,11 @@ python -m tools.export_charts --help
 This ensures that the project root is on `sys.path` and avoids `ImportError`
 issues. For convenience the scripts also include a small `sys.path` fix-up so
 that direct execution (`python tools/export_charts.py`) still works if needed.
+
+## Developer Notes — 2025-09-24 (Delta Pack — merged)
+- Standardized `[DEBUG_EXPORT]` and `[CHARTS]` lines with zero-defaulted counts.
+- Headless mode announced on import; PNGs saved atomically with explicit format and DPI and exports retry once.
+- Knowledge base writes enforce full schema and skip duplicate run IDs.
+- Eval CLI emits a single `[EVAL]` line and guards `latest` lookups with exit code 2.
+- Legacy flags remain accepted as no-ops; CLIs are the supported interface for tests.
+- Migration: consumers should handle new debug lines and extended KB fields when parsing outputs.

--- a/bot_trade/tools/eval_run.py
+++ b/bot_trade/tools/eval_run.py
@@ -16,6 +16,7 @@ from typing import Dict, Any, List
 import matplotlib
 
 matplotlib.use("Agg")
+print(f"[HEADLESS] backend={matplotlib.get_backend()}")
 
 from bot_trade.config.rl_paths import RunPaths, DEFAULT_REPORTS_DIR
 
@@ -33,7 +34,7 @@ def _atomic_png(path: Path, fig) -> None:
     tmp = path.with_suffix(path.suffix + ".tmp")
     fmt = path.suffix.lstrip(".") or "png"
     fig.tight_layout()
-    fig.savefig(tmp, format=fmt)
+    fig.savefig(tmp, format=fmt, dpi=100)
     os.replace(tmp, path)
     plt.close(fig)
     if path.stat().st_size < 1024:

--- a/bot_trade/tools/export_run_charts.py
+++ b/bot_trade/tools/export_run_charts.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:  # pragma: no cover
 import matplotlib
 
 matplotlib.use("Agg")
+print(f"[HEADLESS] backend={matplotlib.get_backend()}")
 import matplotlib.pyplot as plt  # noqa: E402
 
 from bot_trade.config.rl_paths import RunPaths
@@ -263,6 +264,19 @@ def export_for_run(run_paths: RunPaths, debug: bool = False) -> Tuple[Path, int,
         "signals": rows_signals,
     }
 
+    print(
+        "[DEBUG_EXPORT] reward_rows=%d step_rows=%d train_rows=%d risk_rows=%d callbacks_rows=%d signals_rows=%d"
+        % (
+            rows_reward,
+            rows_step,
+            rows_train,
+            rows_risk,
+            callbacks_lines,
+            rows_signals,
+        )
+    )
+    print(f"[CHARTS] dir={charts_dir.resolve()} images={images}")
+
     return charts_dir, images, rows
 
 
@@ -305,19 +319,7 @@ def main(argv: list[str] | None = None) -> int:
             return 2
         run_id = rid
     rp = RunPaths(ns.symbol, ns.frame, run_id, root=root)
-    charts_dir, images, rows = export_for_run(rp)
-    print(
-        "[DEBUG_EXPORT] reward_rows=%d step_rows=%d train_rows=%d risk_rows=%d callbacks_rows=%d signals_rows=%d"
-        % (
-            rows.get("reward", 0),
-            rows.get("step", 0),
-            rows.get("train", 0),
-            rows.get("risk", 0),
-            rows.get("callbacks", 0),
-            rows.get("signals", 0),
-        )
-    )
-    print(f"[CHARTS] dir={charts_dir.resolve()} images={images}")
+    charts_dir, images, _rows = export_for_run(rp)
     return 0 if images > 0 else 2
 
 

--- a/bot_trade/tools/monitor_manager.py
+++ b/bot_trade/tools/monitor_manager.py
@@ -51,20 +51,7 @@ def main(argv: list[str] | None = None) -> int:
                 return 2
         rp = RunPaths(ns.symbol, ns.frame, run_id, root=root)
         from bot_trade.tools import export_run_charts  # lazy heavy import
-
-        charts_dir, images, rows = export_run_charts.export_for_run(rp)
-        print(
-            "[DEBUG_EXPORT] reward_rows=%d step_rows=%d train_rows=%d risk_rows=%d callbacks_rows=%d signals_rows=%d"
-            % (
-                rows.get("reward", 0),
-                rows.get("step", 0),
-                rows.get("train", 0),
-                rows.get("risk", 0),
-                rows.get("callbacks", 0),
-                rows.get("signals", 0),
-            )
-        )
-        print(f"[CHARTS] dir={charts_dir.resolve()} images={images}")
+        charts_dir, images, _rows = export_run_charts.export_for_run(rp)
         return 0 if images > 0 else 2
     except Exception as exc:  # pragma: no cover
         print(f"[ERROR] {exc}", file=sys.stderr)

--- a/bot_trade/train_rl.py
+++ b/bot_trade/train_rl.py
@@ -359,18 +359,6 @@ def _postrun_summary(paths, meta):
     rows_risk = row_counts.get("risk", 0)
     rows_callbacks = row_counts.get("callbacks", 0)
     rows_signals = row_counts.get("signals", 0)
-    print(
-        "[DEBUG_EXPORT] reward_rows=%d step_rows=%d train_rows=%d risk_rows=%d callbacks_rows=%d signals_rows=%d"
-        % (
-            rows_reward,
-            rows_step,
-            rows_train,
-            rows_risk,
-            rows_callbacks,
-            rows_signals,
-        )
-    )
-    print(f"[CHARTS] dir={charts_dir.resolve()} images={img_count}")
     logger.info("[POSTRUN_EXPORT] charts=%s images=%d", charts_dir, img_count)
 
     agents_base = Path(rp.agents)


### PR DESCRIPTION
## Summary
- emit [DEBUG_EXPORT] and [CHARTS] lines from shared chart exporter with headless notice
- streamline monitor manager and eval CLI outputs; add atomic PNG save with explicit DPI
- document Delta Pack merge in developer and change notes

## Testing
- `python -m py_compile bot_trade/config/*.py bot_trade/tools/*.py bot_trade/train_rl.py`
- `python -m bot_trade.tools.monitor_manager --help`
- `python -m bot_trade.tools.export_run_charts --help`
- `python -m bot_trade.tools.eval_run --help`
- `python -m bot_trade.train_rl --symbol BTCUSDT --frame 1m --policy MlpPolicy --device cpu --n-envs 1 --n-steps 64 --batch-size 64 --total-steps 128 --net-arch "64,64" --activation relu --vecnorm --headless --allow-synth --kb-file kb.jsonl --data-dir data_ready`
- `python -m bot_trade.tools.monitor_manager --symbol BTCUSDT --frame 1m --run-id latest`
- `python -m bot_trade.tools.eval_run --symbol BTCUSDT --frame 1m --run-id latest`
- `python -m bot_trade.tools.monitor_manager --symbol NONE --frame 1m --run-id latest; echo EXIT:$?`
- `python -m bot_trade.tools.eval_run --symbol NONE --frame 1m --run-id latest; echo EXIT:$?`
- `python -m bot_trade.tools.export_run_charts --symbol BTCUSDT --frame 1m --run-id latest`
- `python -m bot_trade.tools.export_run_charts --symbol NONE --frame 1m --run-id latest; echo EXIT:$?`


------
https://chatgpt.com/codex/tasks/task_b_68b60736e2d4832db1277628a5e30981