### PR TITLE
refactor: split train helpers

### DIFF
--- a/CHANGE_NOTES.md
+++ b/CHANGE_NOTES.md
@@ -78,6 +78,30 @@ PY`
 
 ## Developer Notes — 2025-09-23
 - A) KB: canonical JSONL appender; atomic writes; schema stabilized; integrated after charts+eval+state.
+
+## 2025-09-01
+- **Files**: `bot_trade/config/rl_args.py`, `bot_trade/config/device.py`, `bot_trade/config/log_setup.py`, `bot_trade/tools/monitor_launch.py`, `bot_trade/tools/run_state.py`, `bot_trade/train_rl.py`, `DEV_NOTES.md`, `CHANGE_NOTES.md`
+- **Rationale**: split train orchestrator utilities into dedicated modules and merge duplicate run-state helpers.
+- **Risks**: consumers importing old helper paths may break; global run_state files deprecated.
+- **Test Steps**: `python -m py_compile bot_trade/config/*.py bot_trade/tools/*.py bot_trade/train_rl.py`, `python -m bot_trade.train_rl --help`, `python -m bot_trade.tools.export_charts --help`, `python -m bot_trade.tools.eval_run --help`, smoke training run with `--allow-synth`.
+
+## Developer Notes — 2025-09-01 (Structural Split & De-dup)
+
+| source                                   | canonical module                 | merged funcs                         | removed |
+|------------------------------------------|----------------------------------|--------------------------------------|---------|
+| `train_rl.validate_args`                 | `config.rl_args.validate_args`   | yes                                   | -       |
+| `train_rl.clamp_batch`                   | `config.rl_args.clamp_batch`     | yes                                   | -       |
+| `train_rl.auto_shape_resources`          | `config.rl_args.auto_shape_resources` | yes                             | -       |
+| `train_rl._maybe_print_device_report`    | `config.device.maybe_print_device_report` | yes                       | -       |
+| `train_rl._logging_monitor_loop`         | `config.log_setup.drain_log_queue` | yes                               | -       |
+| `train_rl._spawn_monitor`                | `tools.monitor_launch.spawn_monitor_manager` | yes                   | -       |
+| `train_rl._update_portfolio_state`       | `tools.run_state.update_portfolio_state` | yes                      | -       |
+| `train_rl._write_run_states`             | `tools.run_state.write_run_state_files` | yes                      | -       |
+| `train_rl._ensure_aux_files`             | removed (perf-dir state only)    | -                                    | yes     |
+
+Shims/Deprecations: internal helpers moved; existing public CLI flags unaffected.
+
+Risks/Migration: callers importing from old locations must switch to canonical modules; global run_state files are no longer updated.
 - B) Charts: Agg backend; ≥5 PNG with placeholders; row counts printed; atomic PNGs.
 - C) Eval: synthetic-first metrics; summary.json + portfolio_state.json; equity/drawdown charts (Agg).
 - D) State: run_state.json + state_latest.json (atomic) after portfolio; events.lock optional.

--- a/DEV_NOTES.md
+++ b/DEV_NOTES.md
@@ -74,3 +74,11 @@ that direct execution (`python tools/export_charts.py`) still works if needed.
 - Added atomic I/O helpers and unified `[DEBUG_EXPORT]`/`[CHARTS]` prints with `latest` guards.
 - Risks/Migration: downstream parsers should tolerate new lines and deprecated shim notices.
 - Next: monitor KB growth and expand eval metrics.
+
+## Developer Notes — 2025-09-01 (train_rl split)
+- Extracted arg validation and auto resource shaping to `config.rl_args`.
+- Device report printer lives in `config.device`.
+- Logging queue drain and monitor spawning moved to `config.log_setup` and `tools.monitor_launch`.
+- Run-state and portfolio writers consolidated in `tools.run_state`; train orchestrator now slimmer.
+- Risks: callers using removed internals must import from new modules. Legacy global run_state files deprecated.
+- Next: finish lifecycle callback consolidation and monitor remaining shims.

--- a/bot_trade/config/device.py
+++ b/bot_trade/config/device.py
@@ -33,3 +33,30 @@ def normalize_device(arg: str | None, env: Dict[str, str]) -> str | None:
         return 'cpu' if idx < 0 else f'cuda:{idx}'
     except ValueError:
         return s
+
+
+def maybe_print_device_report(args) -> None:
+    """Print a simple device report unless ``--quiet-device-report`` is set."""
+    if getattr(args, "quiet_device_report", False):
+        return
+    import torch  # type: ignore
+
+    print("========== DEVICE REPORT ==========")
+    print(f"torch.cuda.is_available(): {torch.cuda.is_available()}")
+    print(f"CUDA device_count: {torch.cuda.device_count()}")
+    if torch.cuda.is_available():
+        for i in range(torch.cuda.device_count()):
+            print(f"  [{i}] {torch.cuda.get_device_name(i)}")
+        try:
+            dev = getattr(args, "device_str", None)
+            if dev and dev.startswith("cuda:"):
+                idx = int(dev.split(":", 1)[1])
+                torch.cuda.set_device(idx)
+                print(f"Selected device index: {idx} -> {torch.cuda.get_device_name(idx)}")
+        except Exception:
+            pass
+    try:
+        print(f"torch.get_num_threads(): {torch.get_num_threads()}")
+    except Exception:
+        pass
+    print("===================================")

--- a/bot_trade/config/log_setup.py
+++ b/bot_trade/config/log_setup.py
@@ -257,6 +257,23 @@ def stop_logging(log_objs: Optional[LogObjects]) -> None:
 
 # Convenience helpers ---------------------------------------------------------
 
+def drain_log_queue(queue, listener) -> None:
+    """Forward records from ``queue`` to ``listener`` until sentinel."""
+    try:
+        while True:
+            try:
+                record = queue.get(True)
+            except (EOFError, BrokenPipeError):
+                break
+            if record is None:
+                break
+            listener.handle(record)
+    finally:
+        try:
+            listener.stop()
+        except Exception:
+            pass
+
 def log_device_report(device_str: str = "cpu") -> None:
     """Small utility to log a one-shot device report to the root logger."""
     logger = logging.getLogger("device")

--- a/bot_trade/tools/run_state.py
+++ b/bot_trade/tools/run_state.py
@@ -1,45 +1,62 @@
+from __future__ import annotations
+
 import argparse
+import datetime as dt
 import json
-import os
 from pathlib import Path
 from typing import Dict
 
-from bot_trade.config.rl_paths import ensure_utf8, memory_dir
+from bot_trade.config.rl_paths import memory_dir
+from bot_trade.tools.atomic_io import write_json
 
-RUN_STATE_PATH = memory_dir() / 'run_state.json'
+RUN_STATE_PATH = memory_dir() / "run_state.json"
 
 
 def load_state(path: Path = RUN_STATE_PATH) -> Dict:
     if not path.exists():
         return {}
     try:
-        return json.loads(path.read_text(encoding='utf-8'))
+        return json.loads(path.read_text(encoding="utf-8"))
     except Exception:
         return {}
 
 
 def save_state(state: Dict, path: Path = RUN_STATE_PATH) -> None:
-    tmp = path.with_suffix('.tmp')
-    with ensure_utf8(tmp, csv_newline=False) as fh:
-        json.dump(state, fh, indent=2)
-    os.replace(tmp, path)
+    write_json(path, state)
 
 
-def main():
+def update_portfolio_state(path: Path, steps: int) -> None:
+    state = {"equity": 0.0, "steps": 0, "last_ts": "", "version": 1}
+    if path.exists():
+        try:
+            state.update(json.loads(path.read_text(encoding="utf-8")))
+        except Exception:
+            pass
+    state["steps"] = int(state.get("steps", 0)) + int(steps)
+    state["last_ts"] = dt.datetime.utcnow().isoformat()
+    write_json(path, state)
+
+
+def write_run_state_files(perf_dir: Path, run_id: str, create_lock: bool = False) -> None:
+    perf_dir.mkdir(parents=True, exist_ok=True)
+    now = dt.datetime.utcnow().isoformat()
+    write_json(perf_dir / "run_state.json", {"status": "idle", "updated_at": now})
+    write_json(perf_dir / "state_latest.json", {"last_run_id": run_id, "updated_at": now})
+    if create_lock:
+        (perf_dir / "events.lock").touch()
+
+
+def main() -> int:
     ap = argparse.ArgumentParser()
-    ap.add_argument('--resume', action='store_true')
-    ap.add_argument('--symbol')
-    ap.add_argument('--frame')
-    args = ap.parse_args()
-    if args.resume:
+    ap.add_argument("--resume", action="store_true")
+    ns = ap.parse_args()
+    if ns.resume:
         st = load_state()
-        if st:
-            print(json.dumps(st, indent=2))
-        else:
-            print('{}')
+        print(json.dumps(st, indent=2) if st else "{}")
     else:
         ap.print_help()
+    return 0
 
 
-if __name__ == '__main__':
-    main()
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- move training argument validators and auto resource shaper into `config.rl_args`
- centralize device report printing in `config.device`
- add reusable log queue drain and monitor spawn helpers
- consolidate run-state and portfolio writers under `tools.run_state`
- slim `train_rl` to orchestration calls only

## Testing
- `python -m py_compile bot_trade/config/*.py bot_trade/tools/*.py bot_trade/train_rl.py`
- `python -m bot_trade.train_rl --help`
- `python -m bot_trade.tools.export_charts --help`
- `python -m bot_trade.tools.eval_run --help`
- `python -m bot_trade.tools.eval_run --symbol TESTCOIN --frame 1m --run-id latest`
- `python -m bot_trade.train_rl --symbol BTCUSDT --frame 1m --device cpu --n-envs 1 --n-steps 32 --batch-size 32 --total-steps 64 --headless --allow-synth --export-min-images 5 --log-every-steps 10 --artifact-every-steps 50 --eval-episodes 1 --debug-export`
- `python -m bot_trade.tools.eval_run --symbol BTCUSDT --frame 1m --run-id d6d32d8e`


------
https://chatgpt.com/codex/tasks/task_b_68b61556a138832da3ef6ee2f3ae571b