### PR TITLE
refactor: centralize atomic writers

### DIFF
--- a/CHANGE_NOTES.md
+++ b/CHANGE_NOTES.md
@@ -136,3 +136,17 @@ Risks/Migration: callers importing from old locations must switch to canonical m
 - **Rationale**: foundation cleanup—single KB appender with atomic helpers, canonical exporter/evaluator with shims, standardized prints and latest guards.
 - **Risks**: consumers parsing old outputs must handle new lines and deprecation warnings; KB writes now strictly JSONL.
 - **Test Steps**: `python -m py_compile bot_trade/config/*.py bot_trade/tools/*.py bot_trade/train_rl.py`; CLI `--help` for monitor/export/eval; synthetic run verifying [DEBUG_EXPORT] → [CHARTS] → [POSTRUN] and `[EVAL]` lines; `--run-id latest` diagnostics.
+## 2025-09-25
+- **Files**: `bot_trade/tools/atomic_io.py`, `bot_trade/tools/runctx.py`, `DEV_NOTES.md`, `CHANGE_NOTES.md`
+- **Rationale**: unify atomic writers under `atomic_io`; PNG writer defaults to `dpi=120`; `runctx.atomic_write_json` becomes a shim.
+- **Risks**: downstream imports should migrate to canonical helpers; increased PNG dpi may slightly enlarge files.
+- **Test Steps**: `python -m py_compile bot_trade/config/*.py bot_trade/tools/*.py bot_trade/train_rl.py`; synthetic training run with `--allow-synth` verifying `[DEBUG_EXPORT]`, `[CHARTS]`, `[POSTRUN]`, `[EVAL]` lines.
+
+## Developer Notes — 2025-09-25 (Foundation + Split)
+- Canonical: `bot_trade.tools.atomic_io.write_json/append_jsonl/write_png`.
+- Shimmed: `bot_trade.tools.runctx.atomic_write_json` → `atomic_io.write_json`.
+- Logic moved: runctx.atomic_write_json → atomic_io.write_json.
+- De-dup Map: atomic JSON writer consolidated; no duplicate text writer.
+- Standardized outputs & latest guards remain.
+- Risks/Migration: update imports from `runctx.atomic_write_json`; PNGs now saved at 120 DPI.
+- Next: prune deprecated helpers and monitor KB size.

--- a/DEV_NOTES.md
+++ b/DEV_NOTES.md
@@ -82,3 +82,11 @@ that direct execution (`python tools/export_charts.py`) still works if needed.
 - Run-state and portfolio writers consolidated in `tools.run_state`; train orchestrator now slimmer.
 - Risks: callers using removed internals must import from new modules. Legacy global run_state files deprecated.
 - Next: finish lifecycle callback consolidation and monitor remaining shims.
+
+## Developer Notes — 2025-09-25 (Foundation + Split)
+- Centralized atomic I/O helpers: `atomic_io.write_json`, `append_jsonl` and `write_png(dpi=120)` are the canon.
+- `runctx.atomic_write_json` is now a deprecated shim delegating to `atomic_io.write_json`.
+- De-dup Map: `runctx.atomic_write_json` → `atomic_io.write_json`.
+- Standardized outputs and latest guards unchanged.
+- Risks/Migration: modules relying on `runctx.atomic_write_json` should migrate; PNGs slightly larger due to higher DPI.
+- Next: remove old text writer and audit remaining shims.

--- a/bot_trade/tools/atomic_io.py
+++ b/bot_trade/tools/atomic_io.py
@@ -38,8 +38,8 @@ def append_jsonl(path: str | Path, data: Any) -> None:
     os.replace(tmp, p)
 
 
-def write_png(path: str | Path, fig) -> None:
-    """Atomically write ``fig`` to ``path`` ensuring size >=1KB."""
+def write_png(path: str | Path, fig, dpi: int = 120) -> None:
+    """Atomically write ``fig`` to ``path`` ensuring size >1KB."""
     from matplotlib.figure import Figure
 
     p = Path(path)
@@ -47,7 +47,7 @@ def write_png(path: str | Path, fig) -> None:
     p.parent.mkdir(parents=True, exist_ok=True)
     assert isinstance(fig, Figure)
     fig.tight_layout()
-    fig.savefig(tmp, format="png", dpi=100)
+    fig.savefig(tmp, format="png", dpi=dpi)
     os.replace(tmp, p)
     size = p.stat().st_size
     if size < 1024:

--- a/bot_trade/tools/runctx.py
+++ b/bot_trade/tools/runctx.py
@@ -1,16 +1,15 @@
-"""Run context helpers: run id generation and atomic filesystem utils."""
+"""Run context helpers: run id generation and filesystem utilities."""
 from __future__ import annotations
 
-import json
 import os
 import subprocess
 from contextlib import contextmanager
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict
 
 from bot_trade.tools.paths import ROOT
 from bot_trade.config.rl_paths import build_paths, new_run_id as _new_run_id
+from bot_trade.tools.atomic_io import write_json
 
 
 def _git_hash() -> str:
@@ -40,15 +39,9 @@ def run_paths(symbol: str, frame: str, run_id: str) -> Dict[str, Path]:
     }
 
 
-def atomic_write_text(path: Path, text: str) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_suffix(path.suffix + ".tmp")
-    tmp.write_text(text, encoding="utf-8")
-    tmp.replace(path)
-
-
 def atomic_write_json(path: Path, data: Dict) -> None:
-    atomic_write_text(path, json.dumps(data, indent=2, ensure_ascii=False))
+    """[DEPRECATED] use :func:`bot_trade.tools.atomic_io.write_json`."""
+    write_json(path, data)
 
 
 @contextmanager


### PR DESCRIPTION
## Summary
- centralize atomic JSON/PNG writers and set PNG default dpi=120
- convert runctx.atomic_write_json into a deprecation shim for atomic_io
- document canonical helpers and shims in project notes

## Testing
- `python -m py_compile bot_trade/config/*.py bot_trade/tools/*.py bot_trade/train_rl.py`
- `python -m bot_trade.tools.gen_synth_data --symbol BTCUSDT --frame 1m --out data_ready`
- `python -m bot_trade.train_rl --symbol BTCUSDT --frame 1m --policy MlpPolicy --device cpu --n-envs 2 --n-steps 512 --batch-size 1024 --total-steps 2048 --net-arch "1024,512,256" --activation silu --vecnorm --headless --allow-synth --kb-file Knowlogy/kb.jsonl --data-dir data_ready`
- `python -m bot_trade.tools.eval_run --symbol BTCUSDT --frame 1m --run-id latest`


------
https://chatgpt.com/codex/tasks/task_b_68b61931e810832d82b28e6b25e93cc2