### PR TITLE
Add SAC algorithm option with scoped paths

### DIFF
--- a/CHANGE_NOTES.md
+++ b/CHANGE_NOTES.md
@@ -163,3 +163,9 @@ Risks/Migration: callers importing from old locations must switch to canonical m
 - Risks: callers that skip the helper may display GUI backends; consumers must handle the new `[HEADLESS]` line.
 - Migration: call `ensure_headless_once` in new CLIs before plotting; update log parsers for the headless notice.
 - Next: expand smoke coverage and track chart file sizes.
+
+## 2025-09-26
+- **Files**: `bot_trade/config/rl_builders.py`, `bot_trade/train_rl.py`, `bot_trade/config/rl_args.py`, `bot_trade/config/rl_paths.py`, `bot_trade/tools/paths.py`, `bot_trade/config/config.yaml`, `DEV_NOTES.md`, `CHANGE_NOTES.md`
+- **Rationale**: Phase 1: introduce SAC alongside PPO with algorithm switch and algorithm-scoped artefact directories.
+- **Risks**: new directory layout may break existing scripts; SAC requires continuous action spaces.
+- **Test Steps**: `python -m py_compile bot_trade/config/rl_builders.py bot_trade/train_rl.py bot_trade/config/rl_args.py bot_trade/config/rl_paths.py bot_trade/tools/paths.py`, `python -m bot_trade.train_rl --help`, `python -m bot_trade.train_rl --symbol BTCUSDT --frame 1m --total-steps 1 --allow-synth --no-monitor --headless`, `python -m bot_trade.train_rl --algorithm SAC --symbol BTCUSDT --frame 1m --total-steps 1 --allow-synth --no-monitor --headless --buffer-size 1000 --learning-starts 1 --train-freq 1 --gradient-steps 1 --batch-size 2 --ent-coef auto`

--- a/DEV_NOTES.md
+++ b/DEV_NOTES.md
@@ -90,3 +90,10 @@ that direct execution (`python tools/export_charts.py`) still works if needed.
 - Standardized outputs and latest guards unchanged.
 - Risks/Migration: modules relying on `runctx.atomic_write_json` should migrate; PNGs slightly larger due to higher DPI.
 - Next: remove old text writer and audit remaining shims.
+
+## Developer Notes — 2025-09-26 (SAC phase 1)
+- What: Added SAC algorithm option with CLI flag/config, algorithm-scoped paths, warm-start utility, and TD3/TQC stubs.
+- Why: prepare off-policy methods alongside PPO.
+- Risks: new path layout may break scripts expecting previous structure; SAC requires continuous action spaces.
+- Migration: specify `--algorithm` or set `rl.algorithm`; update path lookups for new layout.
+- Next: implement TD3/TQC builders and evaluation upgrades.

--- a/bot_trade/config/config.yaml
+++ b/bot_trade/config/config.yaml
@@ -56,6 +56,16 @@ rl:
   checkpoint_every_steps: 500_000
   keep_last_n: 5
   resume_if_found: true
+  sac:
+    buffer_size: 2000000
+    learning_starts: 20000
+    train_freq: 1
+    gradient_steps: 1
+    batch_size: 512
+    tau: 0.005
+    ent_coef: "auto"
+    gamma: 0.99
+    policy_kwargs: {}
 
 # ————— بيئة التداول —————
 env:

--- a/bot_trade/config/rl_args.py
+++ b/bot_trade/config/rl_args.py
@@ -157,7 +157,7 @@ def parse_args():
     ap.add_argument("--gamma", type=float, default=0.99)
     ap.add_argument("--gae-lambda", type=float, default=0.95)
     ap.add_argument("--clip-range", type=float, default=0.2)
-    ap.add_argument("--ent-coef", type=float, default=0.0)
+    ap.add_argument("--ent-coef", type=str, default="0.0")
     ap.add_argument("--vf-coef", type=float, default=0.5)
     ap.add_argument("--max-grad-norm", type=float, default=0.5)
     ap.add_argument("--sde", action="store_true")
@@ -228,6 +228,16 @@ def parse_args():
     ap.add_argument("--export-min-images", type=int, default=5)
     ap.add_argument("--debug-export", action="store_true")
     ap.add_argument("--allow-synth", action="store_true")
+    ap.add_argument("--algorithm", type=str, choices=["PPO", "SAC"], default=None,
+                    help="Choose RL algorithm (default from config.yaml: rl.algorithm)")
+    ap.add_argument("--buffer-size", type=int)
+    ap.add_argument("--learning-starts", type=int)
+    ap.add_argument("--train-freq", type=int)
+    ap.add_argument("--gradient-steps", type=int)
+    ap.add_argument("--tau", type=float)
+    ap.add_argument("--sac-gamma", type=float, help="Override gamma for SAC only")
+    ap.add_argument("--warmstart-from-ppo", type=str,
+                    help="(Optional) path to PPO .zip to warm-start SAC feature extractor")
     args = ap.parse_args()
     level_name = str(getattr(args, "log_level", "INFO")).upper()
     import logging

--- a/bot_trade/tools/paths.py
+++ b/bot_trade/tools/paths.py
@@ -27,21 +27,21 @@ def ensure_dirs(*paths: Path) -> None:
         p.mkdir(parents=True, exist_ok=True)
 
 
-def results_dir(symbol: str, frame: str) -> Path:
+def results_dir(symbol: str, frame: str, algo: str | None = None) -> Path:
     """Return the results directory for ``symbol``/``frame``."""
-    return _results_dir(symbol, frame)
+    return _results_dir(symbol, frame, algo)
 
 
-def agents_dir(symbol: str, frame: str) -> Path:
+def agents_dir(symbol: str, frame: str, algo: str | None = None, run_id: str | None = None) -> Path:
     """Return the agents directory for ``symbol``/``frame``."""
-    return _agents_dir(symbol, frame)
+    return _agents_dir(symbol, frame, algo, run_id)
 
 
-def report_dir(symbol: str, frame: str, run_id: str) -> Path:  # noqa: ARG001
-    """Return the report directory (run_id ignored for compatibility)."""
-    return _reports_dir(symbol, frame)
+def report_dir(symbol: str, frame: str, run_id: str | None = None, algo: str | None = None) -> Path:
+    """Return the report directory."""
+    return _reports_dir(symbol, frame, algo)
 
 
-def logs_dir(symbol: str, frame: str, run_id: str) -> Path:  # noqa: ARG001
-    """Return the logs directory under results (run_id ignored)."""
-    return _logs_dir(symbol, frame)
+def logs_dir(symbol: str, frame: str, run_id: str | None = None, algo: str | None = None) -> Path:
+    """Return the logs directory under results."""
+    return _logs_dir(symbol, frame, run_base=run_id, algo=algo)


### PR DESCRIPTION
## Summary
- support SAC alongside PPO and select via `--algorithm` / `rl.algorithm`
- scope agents/results/reports directories by algorithm
- add optional warm-start of SAC feature extractor from PPO

## Testing
- `python -m py_compile bot_trade/config/rl_builders.py bot_trade/train_rl.py bot_trade/config/rl_args.py bot_trade/config/rl_paths.py bot_trade/tools/paths.py`
- `python -m bot_trade.train_rl --help`
- `python -m bot_trade.train_rl --symbol BTCUSDT --frame 1m --total-steps 1 --allow-synth --no-monitor --headless`
- `python -m bot_trade.train_rl --algorithm SAC --symbol BTCUSDT --frame 1m --total-steps 1 --allow-synth --no-monitor --headless --buffer-size 1000 --learning-starts 1 --train-freq 1 --gradient-steps 1 --batch-size 2 --ent-coef auto` *(fails: ValueError: SAC requires a continuous (Box) action space, but got Discrete)*

------
https://chatgpt.com/codex/tasks/task_b_68b625187974832d856e3195ba1a7328