### PR TITLE
Add algorithm registry with SAC support and metadata

### DIFF
--- a/CHANGE_NOTES.md
+++ b/CHANGE_NOTES.md
@@ -175,3 +175,10 @@ Risks/Migration: callers importing from old locations must switch to canonical m
 - **Rationale**: registry-based algorithm selection with SAC warm-start option, legacy path fallbacks, and algorithm metadata in KB and post-run lines.
 - **Risks**: fallback detection may miss atypical layouts; warm-start assumes PPO checkpoints are compatible; TD3/TQC not yet implemented.
 - **Test Steps**: `python -m py_compile bot_trade/config/rl_builders.py bot_trade/config/rl_args.py bot_trade/config/rl_paths.py bot_trade/tools/kb_writer.py bot_trade/train_rl.py`, `python -m bot_trade.train_rl --symbol BTCUSDT --frame 1m --total-steps 1 --n-envs 1 --n-steps 1 --batch-size 1 --headless --allow-synth`, `python -m bot_trade.train_rl --algorithm SAC --symbol BTCUSDT --frame 1m --total-steps 1 --n-envs 1 --n-steps 1 --batch-size 1 --headless --allow-synth; test $? -eq 1`, run a small script calling `build_algorithm('SAC', Pendulum-v1)` to verify warm-start skip message.
+
+## Developer Notes — 2025-09-02T00:02:38Z (Phase 3)
+- What: registry builder with SAC/TD3/TQC entries, SAC action-space guard & override prints, optional warm-start, algorithm-scoped paths with legacy read-only fallback, POSTRUN/KB include algorithm, explicit exit codes.
+- Why: enable multi-algorithm training and clear user feedback.
+- Risks: path resolution may miss atypical layouts; warm-start assumes PPO checkpoints compatible.
+- Migration: prefer new algo-scoped helpers (`last_agent`, `best_agent`); legacy paths remain read-only.
+- Next: implement TD3/TQC algorithms.

--- a/bot_trade/config/rl_args.py
+++ b/bot_trade/config/rl_args.py
@@ -233,7 +233,7 @@ def parse_args():
         type=str,
         choices=["PPO", "SAC", "TD3", "TQC"],
         default=None,
-        help="Choose RL algorithm (default from config.yaml or PPO)",
+        help="Choose RL algorithm (TD3/TQC stubs; default from config or PPO)",
     )
     ap.add_argument("--buffer-size", type=int)
     ap.add_argument("--learning-starts", type=int)

--- a/bot_trade/config/rl_paths.py
+++ b/bot_trade/config/rl_paths.py
@@ -128,18 +128,6 @@ def _legacy_agents_dir(symbol: str, frame: str, run_id: str | None = None) -> Pa
         base = base / run_id
     return base
 
-
-def latest_agent(symbol: str, frame: str, algo: str | None = None, run_id: str | None = None) -> Path:
-    """Return path to the latest agent checkpoint with legacy fallback."""
-
-    path = agents_dir(symbol, frame, algo, run_id) / "deep_rl.zip"
-    if not path.exists():
-        legacy = _legacy_agents_dir(symbol, frame, run_id) / "deep_rl.zip"
-        if legacy.exists():
-            return legacy
-    return path
-
-
 def best_agent(symbol: str, frame: str, algo: str | None = None, run_id: str | None = None) -> Path:
     """Return path to the best agent checkpoint with legacy fallback."""
 
@@ -149,6 +137,27 @@ def best_agent(symbol: str, frame: str, algo: str | None = None, run_id: str | N
         if legacy.exists():
             return legacy
     return path
+
+
+def last_agent(symbol: str, frame: str, algo: str | None = None, run_id: str | None = None) -> Path:
+    """Return path to the last agent checkpoint with legacy fallback."""
+
+    path = agents_dir(symbol, frame, algo, run_id) / "deep_rl_last.zip"
+    if not path.exists():
+        legacy_dir = _legacy_agents_dir(symbol, frame, run_id)
+        legacy = legacy_dir / "deep_rl_last.zip"
+        if legacy.exists():
+            return legacy
+        legacy_alt = legacy_dir / "deep_rl.zip"
+        if legacy_alt.exists():
+            return legacy_alt
+    return path
+
+
+def latest_agent(symbol: str, frame: str, algo: str | None = None, run_id: str | None = None) -> Path:
+    """Alias for :func:`last_agent` kept for backward compatibility."""
+
+    return last_agent(symbol, frame, algo, run_id)
 
 
 def vecnorm_path(symbol: str, frame: str) -> Path:

--- a/bot_trade/tools/kb_writer.py
+++ b/bot_trade/tools/kb_writer.py
@@ -19,7 +19,7 @@ KB_DEFAULTS = {
     "run_id": "",
     "symbol": "",
     "frame": "",
-    "algorithm": "PPO",
+    "algorithm": None,
     "ts": None,
     "images": 0,
     "rows_reward": 0,

--- a/bot_trade/train_rl.py
+++ b/bot_trade/train_rl.py
@@ -29,7 +29,7 @@ from bot_trade.config.rl_paths import (
     ensure_contract,
     DEFAULT_KB_FILE,
     best_agent,
-    latest_agent,
+    last_agent,
 )
 from bot_trade.config.device import normalize_device, maybe_print_device_report
 from bot_trade.config.rl_callbacks import _save_vecnorm
@@ -429,36 +429,22 @@ def train_one_file(args, data_file: str) -> bool:
     # merge CLI overrides into cfg surface
     if algo == "SAC":
         sac_cfg = cfg.setdefault("sac", {})
-        overrides = {}
         if args.buffer_size is not None:
             sac_cfg["buffer_size"] = int(args.buffer_size)
-            overrides["buffer_size"] = int(args.buffer_size)
         if args.learning_starts is not None:
             sac_cfg["learning_starts"] = int(args.learning_starts)
-            overrides["learning_starts"] = int(args.learning_starts)
         if args.train_freq is not None:
             sac_cfg["train_freq"] = int(args.train_freq)
-            overrides["train_freq"] = int(args.train_freq)
         if args.gradient_steps is not None:
             sac_cfg["gradient_steps"] = int(args.gradient_steps)
-            overrides["gradient_steps"] = int(args.gradient_steps)
         if args.batch_size is not None:
             sac_cfg["batch_size"] = int(args.batch_size)
-            overrides["batch_size"] = int(args.batch_size)
         if args.tau is not None:
             sac_cfg["tau"] = float(args.tau)
-            overrides["tau"] = float(args.tau)
         if args.ent_coef is not None:
             sac_cfg["ent_coef"] = args.ent_coef
-            overrides["ent_coef"] = args.ent_coef
         if getattr(args, "sac_gamma", None) is not None:
             sac_cfg["gamma"] = float(args.sac_gamma)
-            overrides["gamma"] = float(args.sac_gamma)
-        if overrides:
-            line = ", ".join(f"{k}={v}" for k, v in overrides.items())
-            msg = f"[ALGO] SAC overrides: {line}"
-            print(msg)
-            logging.info(msg)
     else:
         ppo_cfg = cfg.setdefault("ppo", {})
         ppo_cfg.update({
@@ -766,7 +752,7 @@ def train_one_file(args, data_file: str) -> bool:
             if not ppo_path:
                 ppo_path = str(best_agent(args.symbol, args.frame, "PPO"))
                 if not os.path.exists(ppo_path):
-                    ppo_path = str(latest_agent(args.symbol, args.frame, "PPO"))
+                    ppo_path = str(last_agent(args.symbol, args.frame, "PPO"))
             if ppo_path and os.path.exists(ppo_path):
                 try:
                     from stable_baselines3 import PPO as _PPO


### PR DESCRIPTION
## Summary
- Introduce registry-driven RL algorithm builder with SAC, PPO, and TD3/TQC stubs
- Guard SAC to continuous action spaces, log user overrides, and allow warm-start from PPO
- Scope agents/results/reports paths and KB entries by algorithm

## Testing
- `python -m py_compile bot_trade/config/*.py bot_trade/tools/*.py bot_trade/train_rl.py`
- `python -m bot_trade.train_rl --help | rg "algorithm" -n`
- `python -m bot_trade.train_rl --symbol BTCUSDT --frame 1m --policy MlpPolicy --device cpu --n-envs 1 --n-steps 8 --batch-size 8 --total-steps 8 --allow-synth --headless --no-monitor --data-dir data_ready`
- `tail -n 1 memory/Knowlogy/kb.jsonl`
- `python -m bot_trade.train_rl --symbol BTCUSDT --frame 1m --device cpu --n-envs 1 --n-steps 8 --batch-size 8 --total-steps 8 --allow-synth --headless --no-monitor --data-dir data_ready --algorithm SAC >/tmp/sac.log; status=$?; cat /tmp/sac.log; echo CODE:$status`
- `python - <<'PY'
import os
from types import SimpleNamespace
import gymnasium as gym
from stable_baselines3.common.vec_env import DummyVecEnv
from bot_trade.config.rl_builders import build_algorithm
from bot_trade.config.rl_paths import best_agent, last_agent

env = DummyVecEnv([lambda: gym.make('Pendulum-v1')])
args = SimpleNamespace(seed=0, device_str='cpu', sb3_verbose=0, tensorboard_log=None,
    buffer_size=None, learning_starts=None, train_freq=None, gradient_steps=None,
    batch_size=None, tau=None, ent_coef='auto', sac_gamma=None, gamma=0.99,
    learning_rate=3e-4, sac_warmstart_from_ppo=True, warmstart_from_ppo=None,
    symbol='FOO', frame='1m')
model = build_algorithm('SAC', env, args, {})
ppo_path = str(best_agent(args.symbol, args.frame, 'PPO'))
if not os.path.exists(ppo_path):
    ppo_path = str(last_agent(args.symbol, args.frame, 'PPO'))
if ppo_path and os.path.exists(ppo_path):
    print('FOUND_PPO')
else:
    print('[ALGO] warm-start skipped: compatible PPO checkpoint not found')
print('MODEL', type(model).__name__)
PY`
- `python -m bot_trade.train_rl --symbol BTCUSDT --frame 1m --device cpu --n-envs 1 --n-steps 8 --batch-size 8 --total-steps 8 --allow-synth --headless --no-monitor --data-dir data_ready --algorithm TD3 >/tmp/td3.log; status=$?; cat /tmp/td3.log; echo CODE:$status`
- `python -m bot_trade.train_rl --symbol BTCUSDT --frame 1m --device cpu --n-envs 1 --n-steps 8 --batch-size 8 --total-steps 8 --allow-synth --headless --no-monitor --data-dir data_ready --algorithm TQC >/tmp/tqc.log; status=$?; cat /tmp/tqc.log; echo CODE:$status`


------
https://chatgpt.com/codex/tasks/task_b_68b6333b47ec832dbae0ec437ecef8ef