### PR TITLE
feat: add algo registry with SAC warmstart

### DIFF
--- a/CHANGE_NOTES.md
+++ b/CHANGE_NOTES.md
@@ -182,3 +182,9 @@ Risks/Migration: callers importing from old locations must switch to canonical m
 - Risks: path resolution may miss atypical layouts; warm-start assumes PPO checkpoints compatible.
 - Migration: prefer new algo-scoped helpers (`last_agent`, `best_agent`); legacy paths remain read-only.
 - Next: implement TD3/TQC algorithms.
+## Developer Notes — 2025-09-02T00:28:13Z (Phase 3)
+- What: finalized algorithm registry with PPO/SAC and TD3/TQC stubs; SAC now guards Box action spaces, prints true overrides, and can warm-start from PPO checkpoints.
+- Why: enable multi-algorithm flexibility with clear user feedback and safe defaults.
+- Risks: warm-start assumes compatible PPO feature extractors; path scoping may miss custom layouts.
+- Migration: use new --algorithm flag and algo-scoped helpers; legacy paths remain read-only fallbacks.
+- Next: implement full TD3/TQC support and expand SAC validation.

--- a/bot_trade/config/rl_args.py
+++ b/bot_trade/config/rl_args.py
@@ -232,8 +232,8 @@ def parse_args():
         "--algorithm",
         type=str,
         choices=["PPO", "SAC", "TD3", "TQC"],
-        default=None,
-        help="Choose RL algorithm (TD3/TQC stubs; default from config or PPO)",
+        default="PPO",
+        help="Choose RL algorithm (TD3/TQC stubs; default PPO unless config overrides)",
     )
     ap.add_argument("--buffer-size", type=int)
     ap.add_argument("--learning-starts", type=int)
@@ -248,7 +248,9 @@ def parse_args():
         action="store_true",
         help="Warm-start SAC feature extractor from best PPO checkpoint if available",
     )
+    defaults = vars(ap.parse_args([]))
     args = ap.parse_args()
+    args._defaults = defaults
     level_name = str(getattr(args, "log_level", "INFO")).upper()
     import logging
     args.log_level = getattr(logging, level_name, logging.INFO)

--- a/bot_trade/config/rl_builders.py
+++ b/bot_trade/config/rl_builders.py
@@ -225,15 +225,12 @@ def build_sac(env, args, policy_kwargs):
     sac_cfg = rl_cfg.get("sac", {}) if isinstance(rl_cfg, dict) else {}
 
     overrides: dict[str, object] = {}
+    defaults = getattr(args, "_defaults", {})
 
     def _get(name, default):
-        sentinel = object()
-        val = getattr(args, name, sentinel)
-        if val is not sentinel and val is not None:
-            if name == "ent_coef" and str(val) == "0.0":
-                pass
-            else:
-                overrides[name] = val
+        val = getattr(args, name, None)
+        if val is not None and val != defaults.get(name):
+            overrides[name] = val
             return val
         return sac_cfg.get(name, rl_cfg.get(name, default))
 


### PR DESCRIPTION
## Summary
- add registry-based RL algorithm builder with SAC and TD3/TQC stubs
- support SAC overrides, Box-space guard, and optional PPO warm-start
- scope artifacts and metadata by algorithm and persist algorithm in POSTRUN/KB

## Testing
- `python -m py_compile bot_trade/config/rl_builders.py bot_trade/config/rl_args.py bot_trade/config/rl_paths.py bot_trade/tools/kb_writer.py bot_trade/train_rl.py`
- `python -m bot_trade.train_rl --help`
- `python -m bot_trade.train_rl --symbol BTCUSDT --frame 1m --total-steps 1 --n-envs 1 --n-steps 2 --batch-size 2 --allow-synth --no-monitor --headless`
- `python - <<'PY'
from types import SimpleNamespace
import os
import gymnasium as gym
from stable_baselines3.common.vec_env import DummyVecEnv
from bot_trade.config.rl_builders import build_algorithm
from bot_trade.config.rl_paths import best_agent, last_agent, get_root

env = DummyVecEnv([lambda: gym.make('Pendulum-v1')])
args = SimpleNamespace(seed=0, device_str='cpu', sb3_verbose=0,
                       buffer_size=None, learning_starts=None, train_freq=None,
                       gradient_steps=None, batch_size=None, tau=None,
                       ent_coef=None, sac_gamma=None, learning_rate=3e-4,
                       sde=False, sac_warmstart_from_ppo=True,
                       warmstart_from_ppo=None, _defaults={})
model = build_algorithm('SAC', env, args, {})
print(type(model).__name__)
candidates=[]
symbol='BTCUSDT'; frame='1m'
candidates.append(best_agent(symbol, frame, 'PPO'))
candidates.append(last_agent(symbol, frame, 'PPO'))
legacy_dir = get_root()/ 'agents'/symbol/'1m'
candidates.extend([legacy_dir/'deep_rl_best.zip', legacy_dir/'deep_rl_last.zip', legacy_dir/'deep_rl.zip'])
sel = next((p for p in candidates if p and os.path.exists(p)), None)
if sel is None:
    print('[ALGO] warm-start skipped: compatible PPO checkpoint not found')
PY`
- `python - <<'PY'
import subprocess, shlex
cmd = 'python -m bot_trade.train_rl --algorithm SAC --symbol BTCUSDT --frame 1m --total-steps 1 --n-envs 1 --n-steps 2 --batch-size 2 --allow-synth --no-monitor --headless'
res = subprocess.run(shlex.split(cmd))
print('exit', res.returncode)
PY`
- `python - <<'PY'
import subprocess, shlex
cmd = 'python -m bot_trade.train_rl --algorithm TD3 --symbol BTCUSDT --frame 1m --total-steps 1 --n-envs 1 --n-steps 2 --batch-size 2 --allow-synth --no-monitor --headless'
res = subprocess.run(shlex.split(cmd))
print('exit', res.returncode)
PY`
- `python - <<'PY'
import subprocess, shlex
cmd = 'python -m bot_trade.train_rl --algorithm TQC --symbol BTCUSDT --frame 1m --total-steps 1 --n-envs 1 --n-steps 2 --batch-size 2 --allow-synth --no-monitor --headless'
res = subprocess.run(shlex.split(cmd))
print('exit', res.returncode)
PY`


------
https://chatgpt.com/codex/tasks/task_b_68b638f246d0832da0df7dfcdbed1130