### PR TITLE
refactor: centralize SAC warm-start

### DIFF
--- a/CHANGE_NOTES.md
+++ b/CHANGE_NOTES.md
@@ -209,3 +209,9 @@ Risks/Migration: callers importing from old locations must switch to canonical m
 - Tearsheet emits NO DATA placeholders and writes HTML/PDF atomically.
 - Risks: consumers must handle None metrics and env overrides.
 - Test Steps: `python -m py_compile bot_trade/config/*.py bot_trade/tools/*.py bot_trade/eval/*.py bot_trade/train_rl.py`; synthetic run then `python -m bot_trade.tools.eval_run --symbol BTCUSDT --frame 1m --run-id latest --wfa-splits 4 --wfa-embargo 0.02 --tearsheet`.
+
+## 2025-09-28
+- **Files**: `bot_trade/config/rl_builders.py`, `bot_trade/train_rl.py`, `DEV_NOTES.md`, `CHANGE_NOTES.md`
+- **Rationale**: move SAC warm-start into builder with prioritized PPO checkpoint search and clearer Box-space guard logging.
+- **Risks**: warm-start resolver may miss unconventional layouts; assumes compatible feature extractors.
+- **Test Steps**: `python -m py_compile bot_trade/config/*.py bot_trade/tools/*.py bot_trade/train_rl.py`; `python -m bot_trade.train_rl --help`; PPO and SAC smoke runs verifying warm-start skip message.

--- a/DEV_NOTES.md
+++ b/DEV_NOTES.md
@@ -112,3 +112,10 @@ that direct execution (`python tools/export_charts.py`) still works if needed.
 - Risks: consumers must handle None metrics and misconfigured report paths; PDF generation still depends on optional dependencies.
 - Migration: set BOT_REPORTS_DIR to redirect reports, handle None in metrics, and install `weasyprint` for PDF output.
 - Next: broaden stability checks to additional metrics and integrate more comprehensive tests.
+
+## Developer Notes — 2025-09-28T00:00:00Z (Phase 3 warm-start relocation)
+- What: moved SAC warm-start into `build_sac` with prioritized PPO checkpoint resolver; `train_rl` no longer duplicates logic.
+- Why: centralize algorithm-specific setup and keep CLI flags authoritative.
+- Risks: resolver may miss unconventional layouts; warm-start assumes compatible feature extractors.
+- Migration: none, existing flags unchanged.
+- Next: implement full TD3/TQC support.


### PR DESCRIPTION
## Summary
- move SAC warm-start logic into `build_sac` with prioritized PPO checkpoint search and clear Box-space enforcement
- include `eval_max_drawdown` in `[POSTRUN]` metadata

## Testing
- `python -m py_compile bot_trade/config/*.py bot_trade/tools/*.py bot_trade/train_rl.py`
- `python -m bot_trade.train_rl --help`
- `python -m bot_trade.train_rl --algorithm PPO --symbol BTCUSDT --frame 1m --device cpu --n-envs 1 --n-steps 32 --batch-size 32 --total-steps 64 --headless --allow-synth --data-dir data_ready`
- `python -m bot_trade.train_rl --algorithm SAC --symbol BTCUSDT --frame 1m --device cpu --n-envs 1 --n-steps 2 --batch-size 2 --total-steps 2 --headless --allow-synth --data-dir data_ready; test $? -eq 1 && echo EXIT_CODE_1`
- `python - <<'PY'
from gymnasium.envs.classic_control import pendulum
from stable_baselines3.common.vec_env import DummyVecEnv
from bot_trade.config.rl_builders import build_sac
class A:
    symbol="BTCUSDT"; frame="1m"; seed=0; device_str="cpu"; sb3_verbose=0
    learning_rate=3e-4; _defaults={}; sac_warmstart_from_ppo=True; warmstart_from_ppo=None
env = DummyVecEnv([lambda: pendulum.PendulumEnv()])
model = build_sac(env, A(), {})
print('done')
PY`
- `python -m bot_trade.train_rl --algorithm TD3 --symbol BTCUSDT --frame 1m --device cpu --n-envs 1 --n-steps 2 --batch-size 2 --total-steps 2 --headless --allow-synth --data-dir data_ready; test $? -eq 2 && echo EXIT_CODE_2`
- `python -m bot_trade.train_rl --algorithm TQC --symbol BTCUSDT --frame 1m --device cpu --n-envs 1 --n-steps 2 --batch-size 2 --total-steps 2 --headless --allow-synth --data-dir data_ready; test $? -eq 2 && echo EXIT_CODE_2`

------
https://chatgpt.com/codex/tasks/task_b_68b64c1bbe00832da95356e532e264cf