### PR TITLE
feat: adaptive regime controller

### DIFF
--- a/CHANGE_NOTES.md
+++ b/CHANGE_NOTES.md
@@ -236,3 +236,9 @@ Risks/Migration: callers importing from old locations must switch to canonical m
 - **Risks**: simplified execution may misprice fills; downstream tools must handle new risk_log order and diagnostic line.
 - **Migration Steps**: consume new CLI flags, update parsers for risk_log columns, accept optional `[RISK_DIAG]` output.
 - **Next Actions**: add regime detection interfaces and wire multi-algo registry.
+
+## 2025-09-02
+- **Files**: `bot_trade/strat/regime.py`, `bot_trade/strat/adaptive_controller.py`, `bot_trade/config/config.yaml`, `bot_trade/config/rl_args.py`, `bot_trade/config/rl_callbacks.py`, `bot_trade/train_rl.py`, `DEV_NOTES.md`
+- **Rationale**: add regime detection and adaptive reward/risk controller, integrate execution hardening logs and charts.
+- **Risks**: misconfigured thresholds may return unknown regimes; extra logging and plotting add minor overhead.
+- **Test Steps**: `python -m py_compile bot_trade/strat/regime.py bot_trade/strat/adaptive_controller.py bot_trade/config/rl_args.py bot_trade/config/rl_callbacks.py bot_trade/train_rl.py`; `python -m bot_trade.train_rl --symbol BTCUSDT --frame 1m --device cpu --n-envs 1 --n-steps 128 --batch-size 128 --total-steps 256 --headless --allow-synth --data-dir data_ready --regime-aware --regime-log`; `python -m bot_trade.tools.monitor_manager --symbol BTCUSDT --frame 1m --run-id latest --tearsheet`; `python -m bot_trade.tools.eval_run --symbol BTCUSDT --frame 1m --run-id latest --tearsheet`; `python -m bot_trade.tools.monitor_manager --symbol FAKE --frame 1m --run-id latest`.

--- a/DEV_NOTES.md
+++ b/DEV_NOTES.md
@@ -126,3 +126,10 @@ that direct execution (`python tools/export_charts.py`) still works if needed.
 - Risks: simplified slippage models and circuit breakers may misrepresent live conditions; downstream tooling must handle new log columns.
 - Migration: update parsing scripts to read `risk_flag` columns and optional execution metrics; adjust configs/CLIs if relying on previous fixed fills.
 - Next: refine depth-aware modelling and expand evaluation around circuit-breaker effectiveness.
+
+## Developer Notes — 2025-09-02T04:20:01Z (Regime-aware & hardening merge)
+- What: added regime detection & adaptive reward/risk controller; enforced log order [DEBUG_EXPORT]→[CHARTS]→[POSTRUN], risk flag CSV schema, placeholder risk_flags.png & regimes.png, [RISK_DIAG] no_flags_fired, headless notice, [LATEST] none exit 2.
+- Why: enable regime-aware training with robust execution safeguards.
+- Risks: misconfigured thresholds may mute controller; extra plotting adds overhead.
+- Migration: supply regime mappings in config, enable with --regime-aware; consumers should parse new adaptive_log.jsonl and KB.regime.
+- Next Actions: refine regime classifier and expose more metrics.

--- a/bot_trade/config/config.yaml
+++ b/bot_trade/config/config.yaml
@@ -382,3 +382,39 @@ risk:
     cooldown_steps: 50
   max_notional: null
   max_units: null
+
+regime:
+  thresholds:
+    volatility:
+      window: 20
+      high: 0.05
+    trend:
+      window: 20
+      up: 0.0005
+      down: -0.0005
+    spread_bp:
+      window: 5
+      high: 10
+    volume:
+      window: 20
+      low: 0.5
+  bounds:
+    max_spread_bp: {min: 0, max: 50}
+    exposure_cap: {min: 0.0, max: 1.0}
+    freeze_after_losses: {min: 1, max: 10}
+  mappings:
+    range:
+      reward_weights: {dd_penalty: 0.35, holding_penalty: 0.02, trend_bonus: 0.0}
+      risk_bounds: {max_spread_bp: 10, exposure_cap: 0.5, freeze_after_losses: 5}
+    trend_up:
+      reward_weights: {dd_penalty: 0.3, holding_penalty: 0.01, trend_bonus: 0.1}
+      risk_bounds: {max_spread_bp: 8, exposure_cap: 0.8, freeze_after_losses: 4}
+    trend_down:
+      reward_weights: {dd_penalty: 0.4, holding_penalty: 0.02, trend_bonus: -0.1}
+      risk_bounds: {max_spread_bp: 8, exposure_cap: 0.8, freeze_after_losses: 4}
+    high_vol:
+      reward_weights: {dd_penalty: 0.5, holding_penalty: 0.03, trend_bonus: 0.0}
+      risk_bounds: {max_spread_bp: 5, exposure_cap: 0.3, freeze_after_losses: 6}
+    low_liquidity:
+      reward_weights: {dd_penalty: 0.4, holding_penalty: 0.03, trend_bonus: 0.0}
+      risk_bounds: {max_spread_bp: 12, exposure_cap: 0.2, freeze_after_losses: 7}

--- a/bot_trade/config/rl_args.py
+++ b/bot_trade/config/rl_args.py
@@ -233,6 +233,9 @@ def parse_args():
     ap.add_argument("--allow-partial-exec", action="store_true")
     ap.add_argument("--slippage-model", type=str, default=None)
     ap.add_argument("--slippage-params", type=str, default=None)
+    ap.add_argument("--regime-aware", action="store_true", help="Enable regime-aware adjustments")
+    ap.add_argument("--regime-window", type=int, default=0, help="Steps between regime checks")
+    ap.add_argument("--regime-log", action=argparse.BooleanOptionalAction, default=None, help="Log adaptive regime adjustments")
     ap.add_argument(
         "--algorithm",
         type=str,
@@ -256,6 +259,8 @@ def parse_args():
     defaults = vars(ap.parse_args([]))
     args = ap.parse_args()
     args._defaults = defaults
+    if args.regime_log is None:
+        args.regime_log = bool(args.regime_aware)
     level_name = str(getattr(args, "log_level", "INFO")).upper()
     import logging
     args.log_level = getattr(logging, level_name, logging.INFO)

--- a/bot_trade/strat/__init__.py
+++ b/bot_trade/strat/__init__.py
@@ -1,0 +1,4 @@
+from .regime import detect_regime
+from .adaptive_controller import AdaptiveController
+
+__all__ = ["detect_regime", "AdaptiveController"]

--- a/bot_trade/strat/adaptive_controller.py
+++ b/bot_trade/strat/adaptive_controller.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import datetime as dt
+import logging
+from collections import Counter
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from .regime import detect_regime
+from bot_trade.tools.atomic_io import append_jsonl
+
+
+class AdaptiveController:
+    """Adjust reward weights and risk bounds based on detected regime."""
+
+    def __init__(
+        self,
+        cfg: Dict[str, Any],
+        env: Optional[Any] = None,
+        log_path: Optional[Path] = None,
+    ) -> None:
+        self.cfg = cfg or {}
+        self.env = env
+        self.log_path = Path(log_path) if log_path else None
+        self.warned = False
+        self.last_regime = "unknown"
+        self.dist: Counter[str] = Counter()
+
+        # baselines
+        rw = getattr(getattr(env, "reward_tracker", None), "w", None)
+        self.base_weights = tuple(rw) if rw else None
+        re = getattr(env, "risk_engine", None)
+        ex = getattr(env, "exec_sim", None)
+        self.base_bounds = {
+            "max_spread_bp": getattr(ex, "max_spread_bp", None),
+            "exposure_cap": getattr(re, "max_risk", None),
+            "freeze_after_losses": getattr(re, "freeze_limit", None),
+        }
+
+    # ----------------------------------------------
+    def update(self, df_slice: Any) -> None:
+        info = detect_regime(df_slice, cfg=self.cfg)
+        regime = info.get("name", "unknown")
+        self.last_regime = regime
+        self.dist[regime] += 1
+
+        mapping = (self.cfg.get("mappings", {}) or {}).get(regime)
+        if not mapping:
+            if not self.warned and regime != "unknown":
+                logging.warning("[REGIME] no mapping for %s", regime)
+                self.warned = True
+            weights = {}
+            bounds = {}
+        else:
+            weights = mapping.get("reward_weights", {})
+            bounds = mapping.get("risk_bounds", {})
+        applied_w = self._apply_weights(weights)
+        applied_b = self._apply_bounds(bounds)
+        if self.log_path:
+            record = {
+                "ts": dt.datetime.utcnow().isoformat(),
+                "regime": regime,
+                "weights": applied_w,
+                "risk_bounds": applied_b,
+            }
+            try:
+                append_jsonl(self.log_path, record)
+            except Exception:
+                pass
+
+    # ----------------------------------------------
+    def _apply_weights(self, weights: Dict[str, Any]) -> Dict[str, Any]:
+        env = self.env
+        tracker = getattr(env, "reward_tracker", None)
+        if tracker is None or not weights:
+            return {}
+        w = list(tracker.w if hasattr(tracker, "w") else self.base_weights or [])
+        if len(w) != 7:
+            return {}
+        changed: Dict[str, Any] = {}
+        if "dd_penalty" in weights:
+            w[2] = float(weights["dd_penalty"])
+            changed["dd_penalty"] = w[2]
+        if "trend_bonus" in weights:
+            w[3] = float(weights["trend_bonus"])
+            changed["trend_bonus"] = w[3]
+        if "holding_penalty" in weights:
+            w[6] = float(weights["holding_penalty"])
+            changed["holding_penalty"] = w[6]
+        tracker.w = tuple(w)
+        return changed
+
+    def _clamp(self, key: str, value: float) -> Optional[float]:
+        lim = (self.cfg.get("bounds", {}) or {}).get(key, {})
+        lo = lim.get("min", float("-inf"))
+        hi = lim.get("max", float("inf"))
+        if value < lo or value > hi:
+            if not self.warned:
+                logging.warning("[REGIME] %s=%s out of bounds [%s,%s]", key, value, lo, hi)
+                self.warned = True
+            return None
+        return value
+
+    def _apply_bounds(self, bounds: Dict[str, Any]) -> Dict[str, Any]:
+        env = self.env
+        re = getattr(env, "risk_engine", None)
+        ex = getattr(env, "exec_sim", None)
+        changed: Dict[str, Any] = {}
+        for k, v in bounds.items():
+            try:
+                val = float(v)
+            except Exception:
+                continue
+            val = self._clamp(k, val)
+            if val is None:
+                continue
+            if k == "max_spread_bp" and ex is not None:
+                ex.max_spread_bp = val
+                changed[k] = val
+            elif k == "exposure_cap" and re is not None:
+                re.max_risk = val
+                changed[k] = val
+            elif k == "freeze_after_losses" and re is not None:
+                re.freeze_limit = int(val)
+                changed[k] = int(val)
+        return changed
+
+    # ----------------------------------------------
+    def get_distribution(self) -> Dict[str, float]:
+        total = sum(self.dist.values())
+        if total == 0:
+            return {}
+        return {k: v / total for k, v in self.dist.items()}

--- a/bot_trade/strat/regime.py
+++ b/bot_trade/strat/regime.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any, Dict
+
+import numpy as np
+import pandas as pd
+
+
+def _to_series(df: pd.DataFrame, col: str) -> pd.Series:
+    try:
+        return pd.to_numeric(df[col], errors="coerce")
+    except Exception:
+        return pd.Series(dtype=float)
+
+
+def detect_regime(df_like: Any, *, cfg: Dict[str, Any]) -> Dict[str, Any]:
+    """Detect simple market regime from price/volume/spread features.
+
+    Parameters
+    ----------
+    df_like : Any
+        DataFrame-like object containing at least close, volume, bid, ask.
+    cfg : dict
+        Threshold configuration with windows and cut-offs.
+
+    Returns
+    -------
+    dict
+        {"name": str, "scores": dict, "ts": iso str}
+    """
+    try:
+        df = pd.DataFrame(df_like).copy()
+    except Exception:
+        df = pd.DataFrame()
+    ts = dt.datetime.utcnow().isoformat()
+    if df.empty:
+        return {"name": "unknown", "scores": {}, "ts": ts}
+
+    try:
+        idx = df.index[-1]
+        if isinstance(idx, (pd.Timestamp, dt.datetime)):
+            ts = idx.isoformat()
+    except Exception:
+        pass
+
+    scores: Dict[str, Any] = {}
+    thr = cfg.get("thresholds", cfg)
+
+    close = _to_series(df, "close")
+    returns = np.log(close).diff()
+    try:
+        vol_win = int(thr.get("volatility", {}).get("window", 20))
+        vol = returns.rolling(vol_win).std().iloc[-1]
+        scores["volatility"] = float(vol) if pd.notna(vol) else None
+    except Exception:
+        scores["volatility"] = None
+
+    try:
+        trend_win = int(thr.get("trend", {}).get("window", 20))
+        log_price = np.log(close)
+        s = log_price.tail(trend_win).dropna()
+        if len(s) >= 2:
+            x = np.arange(len(s))
+            slope, _ = np.polyfit(x, s.values, 1)
+        else:
+            slope = float("nan")
+        scores["trend_slope"] = float(slope) if not np.isnan(slope) else None
+    except Exception:
+        scores["trend_slope"] = None
+
+    try:
+        bid = _to_series(df, "bid")
+        ask = _to_series(df, "ask")
+        mid = (bid + ask) / 2.0
+        sp_win = int(thr.get("spread_bp", {}).get("window", 1))
+        spread_bp = ((ask - bid) / mid).rolling(sp_win).mean().iloc[-1] * 10000
+        scores["spread_bp"] = float(spread_bp) if pd.notna(spread_bp) else None
+    except Exception:
+        scores["spread_bp"] = None
+
+    try:
+        vol_series = _to_series(df, "volume")
+        volw = int(thr.get("volume", {}).get("window", 20))
+        mean_vol = vol_series.rolling(volw).mean().iloc[-1]
+        cur_vol = vol_series.iloc[-1]
+        rel = cur_vol / mean_vol if mean_vol and not np.isnan(mean_vol) else float("nan")
+        scores["volume_rel"] = float(rel) if not np.isnan(rel) else None
+    except Exception:
+        scores["volume_rel"] = None
+
+    if any(v is None for v in scores.values()):
+        return {"name": "unknown", "scores": scores, "ts": ts}
+
+    regime = "range"
+    vol_thr = thr.get("volatility", {}).get("high", float("inf"))
+    trend_up_thr = thr.get("trend", {}).get("up", float("inf"))
+    trend_dn_thr = thr.get("trend", {}).get("down", float("-inf"))
+    spread_thr = thr.get("spread_bp", {}).get("high", float("inf"))
+    vol_low_thr = thr.get("volume", {}).get("low", float("-inf"))
+
+    if scores["volatility"] > vol_thr:
+        regime = "high_vol"
+    elif scores["volume_rel"] < vol_low_thr:
+        regime = "low_liquidity"
+    elif scores["spread_bp"] > spread_thr:
+        regime = "low_liquidity"
+    elif scores["trend_slope"] > trend_up_thr:
+        regime = "trend_up"
+    elif scores["trend_slope"] < trend_dn_thr:
+        regime = "trend_down"
+    else:
+        regime = "range"
+
+    return {"name": regime, "scores": scores, "ts": ts}


### PR DESCRIPTION
## Summary
- add regime detection utilities and adaptive reward/risk controller
- wire regime-aware controller and logging into training loop and callbacks
- expose regime-aware CLI/config knobs and chart regime distribution

## Testing
- `python -m py_compile bot_trade/strat/regime.py bot_trade/strat/adaptive_controller.py bot_trade/config/rl_args.py bot_trade/config/rl_callbacks.py bot_trade/train_rl.py`
- `python -m bot_trade.train_rl --symbol BTCUSDT --frame 1m --device cpu --n-envs 1 --n-steps 128 --batch-size 128 --total-steps 256 --headless --allow-synth --data-dir data_ready --regime-aware --regime-log`
- `python -m bot_trade.tools.monitor_manager --symbol BTCUSDT --frame 1m --run-id latest --tearsheet`
- `python -m bot_trade.tools.eval_run --symbol BTCUSDT --frame 1m --run-id latest --tearsheet`
- `python -m bot_trade.tools.monitor_manager --symbol FAKE --frame 1m --run-id latest ; echo $?`


------
https://chatgpt.com/codex/tasks/task_b_68b66efb79a0832d95722fe4b0b1c3a3