### PR TITLE
Add clamped regime controller and feature registry stub

### DIFF
--- a/CHANGE_NOTES.md
+++ b/CHANGE_NOTES.md
@@ -242,3 +242,10 @@ Risks/Migration: callers importing from old locations must switch to canonical m
 - **Rationale**: add regime detection and adaptive reward/risk controller, integrate execution hardening logs and charts.
 - **Risks**: misconfigured thresholds may return unknown regimes; extra logging and plotting add minor overhead.
 - **Test Steps**: `python -m py_compile bot_trade/strat/regime.py bot_trade/strat/adaptive_controller.py bot_trade/config/rl_args.py bot_trade/config/rl_callbacks.py bot_trade/train_rl.py`; `python -m bot_trade.train_rl --symbol BTCUSDT --frame 1m --device cpu --n-envs 1 --n-steps 128 --batch-size 128 --total-steps 256 --headless --allow-synth --data-dir data_ready --regime-aware --regime-log`; `python -m bot_trade.tools.monitor_manager --symbol BTCUSDT --frame 1m --run-id latest --tearsheet`; `python -m bot_trade.tools.eval_run --symbol BTCUSDT --frame 1m --run-id latest --tearsheet`; `python -m bot_trade.tools.monitor_manager --symbol FAKE --frame 1m --run-id latest`.
+
+## 2025-09-02
+- **Files**: bot_trade/strat/adaptive_controller.py, bot_trade/config/env_trading.py, bot_trade/strat/strategy_features.py, bot_trade/strat/__init__.py, DEV_NOTES.md, CHANGE_NOTES.md
+- **Rationale**: clamp adaptive controller parameters with baseline restoration, expose regime in env info, and introduce strategy feature registry stub.
+- **Risks**: mis-specified bounds may be silently clipped; registry currently unused.
+- **Test Steps**: `python -m py_compile bot_trade/config/*.py bot_trade/tools/*.py bot_trade/strat/*.py bot_trade/train_rl.py`; `python -m bot_trade.tools.gen_synth_data --symbol BTCUSDT --frame 1m --out data_ready`; `python -m bot_trade.train_rl --symbol BTCUSDT --frame 1m --device cpu --n-envs 1 --n-steps 128 --batch-size 128 --total-steps 256 --headless --allow-synth --data-dir data_ready --regime-aware --regime-log --regime-window 5`; `python -m bot_trade.tools.monitor_manager --symbol BTCUSDT --frame 1m --run-id latest --tearsheet`; `python -m bot_trade.tools.eval_run --symbol BTCUSDT --frame 1m --run-id latest --tearsheet`; `python -m bot_trade.tools.monitor_manager --symbol FAKE --frame 1m --run-id latest`.
+

--- a/DEV_NOTES.md
+++ b/DEV_NOTES.md
@@ -133,3 +133,11 @@ that direct execution (`python tools/export_charts.py`) still works if needed.
 - Risks: misconfigured thresholds may mute controller; extra plotting adds overhead.
 - Migration: supply regime mappings in config, enable with --regime-aware; consumers should parse new adaptive_log.jsonl and KB.regime.
 - Next Actions: refine regime classifier and expose more metrics.
+
+## Developer Notes — 2025-09-02T04:51:04Z (Regime clamps & features registry)
+- What: clamped adaptive controller with baseline restoration and env-exposed regime; added pluggable strategy feature registry stub.
+- Why: prevent runaway risk settings and prep strategy plug-ins.
+- Risks: mis-specified bounds may silently clamp; registry unused until plugins land.
+- Migration: none; import from bot_trade.strat.strategy_features for future extensions.
+- Next Actions: add concrete feature providers and expand regime metrics.
+

--- a/bot_trade/config/env_trading.py
+++ b/bot_trade/config/env_trading.py
@@ -115,6 +115,7 @@ class TradingEnv(Env):
         rw_cfg = (self.config or {}).get("reward_shaping", {})
         self.reward_tracker = RewardSignalTracker(rw_cfg)
         self.current_signals: Dict[str, int] = {}
+        self.current_regime = "unknown"
 
         # spaces
         self.obs_cols = self.df.select_dtypes(include=[np.number]).columns.tolist()
@@ -202,7 +203,7 @@ class TradingEnv(Env):
         self.prev_value = self.initial_balance
         self.equity_curve.clear(); self.max_drawdown = 0.0
         obs = self._make_obs()
-        info = {"symbol": self.current_symbol, "frame": self.frame}
+        info = {"symbol": self.current_symbol, "frame": self.frame, "regime": getattr(self, "current_regime", "unknown")}
         return obs, info
 
     def step(self, action: int):
@@ -372,6 +373,7 @@ class TradingEnv(Env):
             "signals_active": [k for k,v in entry_sigs.items() if int(v)==1],
             "entry_blocked": (decision_reason == "ai_guard"), "decision_reason": decision_reason,
             "term_reason": term_reason,
+            "regime": getattr(self, "current_regime", "unknown"),
         }
         if exec_res:
             info.update(

--- a/bot_trade/strat/__init__.py
+++ b/bot_trade/strat/__init__.py
@@ -1,4 +1,11 @@
 from .regime import detect_regime
 from .adaptive_controller import AdaptiveController
+from .strategy_features import build_features, FEATURE_REGISTRY, get_feature_builder
 
-__all__ = ["detect_regime", "AdaptiveController"]
+__all__ = [
+    "detect_regime",
+    "AdaptiveController",
+    "build_features",
+    "FEATURE_REGISTRY",
+    "get_feature_builder",
+]

--- a/bot_trade/strat/adaptive_controller.py
+++ b/bot_trade/strat/adaptive_controller.py
@@ -43,6 +43,11 @@ class AdaptiveController:
         regime = info.get("name", "unknown")
         self.last_regime = regime
         self.dist[regime] += 1
+        if self.env is not None:
+            try:
+                setattr(self.env, "current_regime", regime)
+            except Exception:
+                pass
 
         mapping = (self.cfg.get("mappings", {}) or {}).get(regime)
         if not mapping:
@@ -72,58 +77,69 @@ class AdaptiveController:
     def _apply_weights(self, weights: Dict[str, Any]) -> Dict[str, Any]:
         env = self.env
         tracker = getattr(env, "reward_tracker", None)
-        if tracker is None or not weights:
+        if tracker is None:
             return {}
-        w = list(tracker.w if hasattr(tracker, "w") else self.base_weights or [])
+        w = list(self.base_weights or getattr(tracker, "w", []))
         if len(w) != 7:
             return {}
-        changed: Dict[str, Any] = {}
-        if "dd_penalty" in weights:
-            w[2] = float(weights["dd_penalty"])
-            changed["dd_penalty"] = w[2]
-        if "trend_bonus" in weights:
-            w[3] = float(weights["trend_bonus"])
-            changed["trend_bonus"] = w[3]
-        if "holding_penalty" in weights:
-            w[6] = float(weights["holding_penalty"])
-            changed["holding_penalty"] = w[6]
+        applied = {
+            "dd_penalty": w[2],
+            "trend_bonus": w[3],
+            "holding_penalty": w[6],
+        }
+        if weights:
+            if "dd_penalty" in weights:
+                w[2] = float(weights["dd_penalty"])
+                applied["dd_penalty"] = w[2]
+            if "trend_bonus" in weights:
+                w[3] = float(weights["trend_bonus"])
+                applied["trend_bonus"] = w[3]
+            if "holding_penalty" in weights:
+                w[6] = float(weights["holding_penalty"])
+                applied["holding_penalty"] = w[6]
         tracker.w = tuple(w)
-        return changed
+        return applied
 
     def _clamp(self, key: str, value: float) -> Optional[float]:
         lim = (self.cfg.get("bounds", {}) or {}).get(key, {})
-        lo = lim.get("min", float("-inf"))
-        hi = lim.get("max", float("inf"))
-        if value < lo or value > hi:
-            if not self.warned:
-                logging.warning("[REGIME] %s=%s out of bounds [%s,%s]", key, value, lo, hi)
-                self.warned = True
-            return None
-        return value
+        lo = float(lim.get("min", float("-inf")))
+        hi = float(lim.get("max", float("inf")))
+        clamped = max(lo, min(value, hi))
+        if clamped != value and not self.warned:
+            logging.warning("[REGIME] %s=%s clamped to [%s,%s]", key, value, lo, hi)
+            self.warned = True
+        return clamped
 
     def _apply_bounds(self, bounds: Dict[str, Any]) -> Dict[str, Any]:
         env = self.env
         re = getattr(env, "risk_engine", None)
         ex = getattr(env, "exec_sim", None)
-        changed: Dict[str, Any] = {}
-        for k, v in bounds.items():
+        base = dict(self.base_bounds)
+        if bounds:
+            base.update(bounds)
+        applied: Dict[str, Any] = {}
+        if "max_spread_bp" in base and ex is not None:
             try:
-                val = float(v)
-            except Exception:
-                continue
-            val = self._clamp(k, val)
-            if val is None:
-                continue
-            if k == "max_spread_bp" and ex is not None:
+                val = self._clamp("max_spread_bp", float(base["max_spread_bp"]))
                 ex.max_spread_bp = val
-                changed[k] = val
-            elif k == "exposure_cap" and re is not None:
+                applied["max_spread_bp"] = val
+            except Exception:
+                pass
+        if "exposure_cap" in base and re is not None:
+            try:
+                val = self._clamp("exposure_cap", float(base["exposure_cap"]))
                 re.max_risk = val
-                changed[k] = val
-            elif k == "freeze_after_losses" and re is not None:
+                applied["exposure_cap"] = val
+            except Exception:
+                pass
+        if "freeze_after_losses" in base and re is not None:
+            try:
+                val = self._clamp("freeze_after_losses", float(base["freeze_after_losses"]))
                 re.freeze_limit = int(val)
-                changed[k] = int(val)
-        return changed
+                applied["freeze_after_losses"] = int(val)
+            except Exception:
+                pass
+        return applied
 
     # ----------------------------------------------
     def get_distribution(self) -> Dict[str, float]:

--- a/bot_trade/strat/strategy_features.py
+++ b/bot_trade/strat/strategy_features.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+"""Strategy feature registry stub.
+
+Plugins can register additional feature builders by updating
+``FEATURE_REGISTRY`` at import time. Training code will later select a
+builder via :func:`get_feature_builder`.
+"""
+
+from typing import Any, Callable, Dict
+
+
+def build_features(df_like, cfg) -> Dict[str, Any]:
+    """Baseline feature builder returning an empty feature set."""
+    return {}
+
+FEATURE_REGISTRY: Dict[str, Callable[[Any, Dict[str, Any]], Dict[str, Any]]] = {
+    "baseline": build_features,
+}
+
+
+def get_feature_builder(name: str) -> Callable[[Any, Dict[str, Any]], Dict[str, Any]]:
+    """Select a feature builder by name from ``FEATURE_REGISTRY``."""
+    return FEATURE_REGISTRY.get(name, build_features)


### PR DESCRIPTION
## Summary
- clamp adaptive controller reward/risk settings with baseline restoration and env regime exposure
- expose current regime in env info and add strategy feature registry stub
- document new clamps and registry in developer notes and change log

## Testing
- `python -m py_compile bot_trade/config/*.py bot_trade/tools/*.py bot_trade/strat/*.py bot_trade/train_rl.py`
- `python -m bot_trade.tools.gen_synth_data --symbol BTCUSDT --frame 1m --out data_ready`
- `python -m bot_trade.train_rl --symbol BTCUSDT --frame 1m --device cpu --n-envs 1 --n-steps 128 --batch-size 128 --total-steps 256 --headless --allow-synth --data-dir data_ready --regime-aware --regime-log --regime-window 5`
- `python -m bot_trade.tools.monitor_manager --symbol BTCUSDT --frame 1m --run-id latest --tearsheet`
- `python -m bot_trade.tools.eval_run --symbol BTCUSDT --frame 1m --run-id latest --tearsheet`
- `python -m bot_trade.tools.monitor_manager --symbol FAKE --frame 1m --run-id latest`
- `python -m bot_trade.tools.eval_run --symbol FAKE --frame 1m --run-id latest`


------
https://chatgpt.com/codex/tasks/task_b_68b6771b81c0832db4dcd64ce042525f