### PR TITLE
Add strategy failure safety policy and logs

### DIFF
--- a/CHANGE_NOTES.md
+++ b/CHANGE_NOTES.md
@@ -230,6 +230,12 @@ Risks/Migration: callers importing from old locations must switch to canonical m
 - **Risks**: simplified models may not capture real market behavior; new risk flags require downstream parsers to handle additional columns.
 - **Test Steps**: `python -m py_compile bot_trade/env/execution_sim.py bot_trade/config/env_trading.py bot_trade/config/risk_manager.py bot_trade/config/rl_callbacks.py bot_trade/config/rl_args.py bot_trade/tools/gen_synth_data.py bot_trade/tools/kb_writer.py bot_trade/train_rl.py`; `python -m bot_trade.tools.gen_synth_data --symbol BTCUSDT --frame 1m --out data_ready`; `python -m bot_trade.train_rl --symbol BTCUSDT --frame 1m --device cpu --n-envs 1 --n-steps 256 --batch-size 256 --total-steps 512 --headless --allow-synth --data-dir data_ready --slippage-model vol_aware --slippage-params '{"k":0.5,"vol_window":50}' --latency-ms 40 --max-spread-bp 20 --allow-partial-exec`; `python -m bot_trade.tools.monitor_manager --symbol BTCUSDT --frame 1m --run-id latest --tearsheet`
 
+## 2025-09-30
+- **Files**: `bot_trade/config/strategy_failure.py`, `bot_trade/config/stratigy_failure.py`, `bot_trade/config/env_trading.py`, `bot_trade/config/rl_callbacks.py`, `bot_trade/config/rl_args.py`, `bot_trade/config/config.yaml`, `bot_trade/train_rl.py`, `bot_trade/tools/export_charts.py`, `CHANGE_NOTES.md`, `DEV_NOTES.md`
+- **Rationale**: consolidate strategy failure modules and add safety policy with clamps, logs, chart export, and CLI flags.
+- **Risks**: aggressive clamps may reduce trading activity; additional callbacks add slight overhead.
+- **Test Steps**: `python -m py_compile bot_trade/config/*.py bot_trade/tools/*.py bot_trade/strat/*.py bot_trade/env/*.py bot_trade/train_rl.py`; `python -m bot_trade.tools.gen_synth_data --symbol BTCUSDT --frame 1m --out data_ready`; `python -m bot_trade.train_rl --symbol BTCUSDT --frame 1m --device cpu --n-envs 1 --n-steps 64 --batch-size 64 --total-steps 128 --headless --allow-synth --data-dir data_ready`
+
 ## Developer Notes — 2025-09-02 03:41:34Z
 - **What**: execution simulator models with unified params; structured risk circuit breakers and logs; CLI overrides for slippage/latency/partial/max-spread; evaluation turnover & slippage proxies; headless prints and latest guards unified; POSTRUN/KB enriched with algorithm and eval_max_drawdown.
 - **Why**: prepare pluggable execution and risk safety foundation with consistent reporting.

--- a/DEV_NOTES.md
+++ b/DEV_NOTES.md
@@ -141,3 +141,10 @@ that direct execution (`python tools/export_charts.py`) still works if needed.
 - Migration: none; import from bot_trade.strat.strategy_features for future extensions.
 - Next Actions: add concrete feature providers and expand regime metrics.
 
+
+## Developer Notes — 2025-09-30T00:00:00Z
+- What: consolidated strategy_failure modules, added safety policy with clamps, logs, and safety chart.
+- Why: unify failure handling and escalate actions for risky regimes.
+- Risks: policy may over-trigger and limit trading.
+- Migration: import from `config.strategy_failure`; configure `strategy_failure` block and CLI overrides.
+- Next Actions: integrate strategy selector and regime-based comparisons.

--- a/bot_trade/config/config.yaml
+++ b/bot_trade/config/config.yaml
@@ -383,6 +383,28 @@ risk:
   max_notional: null
   max_units: null
 
+strategy_failure:
+  enabled: true
+  actions:
+    - warn
+    - reduce_risk
+    - freeze_trading
+    - flat_all
+    - halt_training
+  thresholds:
+    loss_streak: 5
+    max_drawdown_bp: 500
+    spread_jump_bp: 50
+    slippage_spike_bp: 50
+    liquidity_drop_pct: 50
+    stuck_position_s: 300
+    partial_fill_timeout_s: 60
+  cool_down_steps: 100
+  clamps:
+    exposure_cap: {min: 0.0, max: 1.0}
+    max_spread_bp: {min: 0, max: 500}
+    risk_scale: {min: 0.1, max: 1.0}
+
 regime:
   thresholds:
     volatility:

--- a/bot_trade/config/rl_args.py
+++ b/bot_trade/config/rl_args.py
@@ -236,6 +236,12 @@ def parse_args():
     ap.add_argument("--regime-aware", action="store_true", help="Enable regime-aware adjustments")
     ap.add_argument("--regime-window", type=int, default=0, help="Steps between regime checks")
     ap.add_argument("--regime-log", action=argparse.BooleanOptionalAction, default=None, help="Log adaptive regime adjustments")
+    ap.add_argument("--strategy-failure", action=argparse.BooleanOptionalAction, default=None, help="Enable strategy failure policy")
+    ap.add_argument("--safety-every", type=int, default=1, help="Check safety every N steps")
+    ap.add_argument("--loss-streak", type=int)
+    ap.add_argument("--max-drawdown-bp", type=float)
+    ap.add_argument("--spread-jump-bp", type=float)
+    ap.add_argument("--slippage-spike-bp", type=float)
     ap.add_argument(
         "--algorithm",
         type=str,

--- a/bot_trade/config/strategy_failure.py
+++ b/bot_trade/config/strategy_failure.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+import datetime as dt
+from collections import Counter
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from bot_trade.tools.atomic_io import append_jsonl
+
+CONFIG: Dict[str, Any] = {}
+STATE: Dict[str, int] = {"level": 0, "cool": 0}
+
+
+def configure(cfg: Dict[str, Any]) -> None:
+    """Set global configuration for strategy failure policy."""
+    CONFIG.clear()
+    CONFIG.update(cfg or {})
+
+
+def _now() -> str:
+    return dt.datetime.utcnow().isoformat()
+
+
+def evaluate_step(ctx: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Return zero or more failure events detected this step."""
+    if not CONFIG.get("enabled", False):
+        return []
+    thr = CONFIG.get("thresholds", {}) or {}
+    events: List[Dict[str, Any]] = []
+    ts = ctx.get("ts") or _now()
+    for key, limit in thr.items():
+        val = ctx.get(key)
+        if val is None or limit is None:
+            continue
+        try:
+            v = float(val)
+            lim = float(limit)
+        except Exception:
+            continue
+        trig = v >= lim if key in {"loss_streak", "stuck_position_s", "partial_fill_timeout_s"} else v > lim
+        if trig:
+            events.append({
+                "flag": key,
+                "reason": f"{key} threshold",
+                "value": v,
+                "threshold": lim,
+                "ts": ts,
+            })
+    return events
+
+
+def _clamp(key: str, value: float) -> float:
+    clamp_cfg = (CONFIG.get("clamps") or {}).get(key, {})
+    lo = float(clamp_cfg.get("min", float("-inf")))
+    hi = float(clamp_cfg.get("max", float("inf")))
+    return max(lo, min(value, hi))
+
+
+def apply_actions(
+    events: List[Dict[str, Any]],
+    *,
+    risk_manager: Any = None,
+    controller: Any = None,
+    env: Any = None,
+    log_path: Optional[Path] = None,
+) -> Dict[str, Any]:
+    """Escalate actions based on policy and record events."""
+    summary: Dict[str, Any] = {"applied_actions": [], "new_risk_bounds": {}}
+    if not events:
+        if STATE.get("cool", 0) > 0:
+            STATE["cool"] -= 1
+            if STATE["cool"] <= 0:
+                STATE["level"] = 0
+        return summary
+
+    STATE["cool"] = int(CONFIG.get("cool_down_steps", 0))
+    actions = CONFIG.get("actions", [])
+    level = STATE.get("level", 0)
+
+    for ev in events:
+        try:
+            if risk_manager is not None:
+                risk_manager.record_flag(ev["flag"], ev["reason"], ev["value"], ev["threshold"])
+        except Exception:
+            pass
+
+    applied: List[str] = []
+    new_bounds: Dict[str, float] = {}
+    if level < len(actions):
+        act = actions[level]
+        if act == "reduce_risk" and risk_manager is not None:
+            try:
+                factor = 0.5
+                if getattr(controller, "last_regime", None) in {"high_vol", "low_liquidity"}:
+                    factor *= 0.8
+                risk_manager.current_risk = _clamp("risk_scale", risk_manager.current_risk * factor)
+                new_bounds["risk_scale"] = risk_manager.current_risk
+                if env is not None and hasattr(env, "exec_sim"):
+                    env.exec_sim.max_spread_bp = _clamp("max_spread_bp", getattr(env.exec_sim, "max_spread_bp", 0.0) * factor)
+                    new_bounds["max_spread_bp"] = env.exec_sim.max_spread_bp
+            except Exception:
+                pass
+        elif act == "freeze_trading" and env is not None:
+            try:
+                setattr(env, "trading_frozen", True)
+            except Exception:
+                pass
+        elif act == "flat_all" and env is not None:
+            try:
+                flat = getattr(env, "flat_all", None)
+                if callable(flat):
+                    flat()
+            except Exception:
+                pass
+        elif act == "halt_training":
+            summary["halt"] = True
+        applied.append(act)
+        level += 1
+        if controller is not None and getattr(controller, "log_path", None) and act != "warn":
+            record = {"ts": _now(), "source": "safety", "action": act, "risk_bounds": new_bounds}
+            try:
+                append_jsonl(controller.log_path, record)
+            except Exception:
+                pass
+
+    STATE["level"] = level
+
+    if log_path is not None:
+        for ev in events:
+            rec = dict(ev)
+            rec["actions"] = applied
+            try:
+                append_jsonl(log_path, rec)
+            except Exception:
+                pass
+
+    summary["applied_actions"] = applied
+    summary["new_risk_bounds"] = new_bounds
+    return summary

--- a/bot_trade/config/stratigy_failure.py
+++ b/bot_trade/config/stratigy_failure.py
@@ -1,0 +1,2 @@
+from .strategy_failure import *  # noqa
+print("[DEPRECATED] bot_trade/config/stratigy_failure.py → use config/strategy_failure.py")


### PR DESCRIPTION
## Summary
- consolidate strategy failure module and add deprecated shim
- add configurable safety policy with clamps, logging and chart export
- expose safety flags via env and training callbacks

## Testing
- `python -m py_compile $(git ls-files 'bot_trade/config/*.py' 'bot_trade/tools/*.py' 'bot_trade/strat/*.py' 'bot_trade/env/*.py' 'bot_trade/train_rl.py')`
- `python -m bot_trade.tools.gen_synth_data --symbol BTCUSDT --frame 1m --out data_ready`
- `python -m bot_trade.train_rl --symbol BTCUSDT --frame 1m --device cpu --n-envs 1 --n-steps 64 --batch-size 64 --total-steps 128 --headless --allow-synth --data-dir data_ready`
- `python -m bot_trade.tools.monitor_manager --symbol FAKE --frame 1m --run-id latest`
- `python -m bot_trade.tools.eval_run --symbol FAKE --frame 1m --run-id latest`


------
https://chatgpt.com/codex/tasks/task_b_68b67b92e88c832dbd0fe525e784e783