### PR TITLE
Consolidate headless notice and latest guards

### DIFF
--- a/CHANGE_NOTES.md
+++ b/CHANGE_NOTES.md
@@ -303,3 +303,9 @@ Risks/Migration: callers importing from old locations must switch to canonical m
 - Sweeper and dev checks ensure chart sizes, KB fields, and provide CI coverage.
 - Knowledge base appends enforce full schema, skip duplicates, and record algorithm metadata.
 - Next: implement full TD3/TQC support and expand regime metrics.
+
+## 2025-10-06
+- **Files**: `bot_trade/tools/_headless.py`, `bot_trade/tools/export_charts.py`, `bot_trade/tools/eval_run.py`, `bot_trade/tools/monitor_manager.py`, `DEV_NOTES.md`, `CHANGE_NOTES.md`
+- **Rationale**: ensure single `[HEADLESS] backend=Agg` notice per CLI, expose `eval_max_drawdown` on `[POSTRUN]`, and harden `--run-id latest` guards across export/eval/monitor tools.
+- **Risks**: base path overrides may diverge from `BOT_REPORTS_DIR`.
+- **Test Steps**: `python -m py_compile $(git ls-files '*.py')`; synthetic run `python -m bot_trade.tools.gen_synth_data --symbol BTCUSDT --frame 1m --out data_ready`; `python -m bot_trade.train_rl --algorithm PPO --symbol BTCUSDT --frame 1m --device cpu --n-envs 1 --n-steps 32 --batch-size 32 --total-steps 64 --headless --allow-synth --data-dir data_ready`; missing-run guards `python -m bot_trade.tools.monitor_manager --symbol FAKE --frame 1m --run-id latest; test $? -eq 2 && echo EXIT_CODE_2`; same for `export_charts` and `eval_run`; evaluation `python -m bot_trade.tools.eval_run --symbol BTCUSDT --frame 1m --run-id latest`.

--- a/DEV_NOTES.md
+++ b/DEV_NOTES.md
@@ -183,3 +183,10 @@ that direct execution (`python tools/export_charts.py`) still works if needed.
 - Risks: large sweeps may still be slow; smoke workflow covers only minimal steps.
 - Migration: run `python -m bot_trade.tools.sweep` for CPU grids; inspect `smoke.yml` for CI expectations.
 - Contracts: single headless notice preserved; `[LATEST] none` returns exit 2; CSV/MD/JSONL written atomically.
+
+## Developer Notes — 2025-10-06T00:00:00Z (Headless notice & latest guards)
+- What: consolidated single `[HEADLESS] backend=Agg` notice per CLI, moved backend selection into entrypoints, appended `[POSTRUN]` in `eval_run` with `eval_max_drawdown`, and hardened `--run-id latest` guards across export/eval/monitor.
+- Why: avoid duplicate headless prints, surface max drawdown in eval summaries, and ensure predictable exits when no runs exist.
+- Risks: base-directory overrides may still misalign with `BOT_REPORTS_DIR`.
+- Migration Steps: none; CLIs remain unchanged but consumers should expect updated headless line and POSTRUN metrics.
+- Next Actions: unify path resolution for custom report roots.

--- a/bot_trade/tools/_headless.py
+++ b/bot_trade/tools/_headless.py
@@ -7,7 +7,7 @@ import matplotlib
 _DONE = False
 
 
-def ensure_headless_once(cli_name: str) -> None:
+def ensure_headless_once(cli_name: str | None = None) -> None:
     """Force matplotlib backend to Agg and print once."""
     global _DONE
     if matplotlib.get_backend().lower() != "agg":
@@ -15,5 +15,5 @@ def ensure_headless_once(cli_name: str) -> None:
     if not _DONE:
         backend = matplotlib.get_backend()
         backend = backend[0].upper() + backend[1:] if backend else backend
-        print(f"[HEADLESS] backend={backend} cli={cli_name}")
+        print(f"[HEADLESS] backend={backend}")
         _DONE = True

--- a/bot_trade/tools/eval_run.py
+++ b/bot_trade/tools/eval_run.py
@@ -167,6 +167,16 @@ def main(argv: list[str] | None = None) -> int:
         ts_path = generate_tearsheet(rp, pdf=args.pdf)
         print(f"[TEARSHEET] out={ts_path.resolve()}")
 
+    print(
+        "[POSTRUN] run_id=%s eval_win_rate=%s eval_sharpe=%s eval_max_drawdown=%s"
+        % (
+            run_id,
+            _fmt(summary.get("win_rate")),
+            _fmt(summary.get("sharpe")),
+            _fmt(summary.get("max_drawdown")),
+        )
+    )
+
     return 0
 
 

--- a/bot_trade/tools/export_charts.py
+++ b/bot_trade/tools/export_charts.py
@@ -14,7 +14,7 @@ from typing import Dict, Any, Tuple
 
 import pandas as pd
 
-from bot_trade.config.rl_paths import RunPaths
+from bot_trade.config.rl_paths import RunPaths, DEFAULT_REPORTS_DIR
 from bot_trade.tools.atomic_io import write_png
 from bot_trade.tools.latest import latest_run
 from bot_trade.tools._headless import ensure_headless_once
@@ -305,7 +305,8 @@ def main(argv: list[str] | None = None) -> int:  # pragma: no cover - CLI helper
     root = Path(ns.base) if ns.base else get_root()
     rid = ns.run_id
     if str(rid).lower() in {"latest", "last"}:
-        rid = latest_run(ns.symbol, ns.frame, root / "reports")
+        reports_root = (Path(ns.base).resolve() / "reports" if ns.base else Path(DEFAULT_REPORTS_DIR))
+        rid = latest_run(ns.symbol, ns.frame, reports_root / "PPO")
         if not rid:
             print("[LATEST] none")
             return 2

--- a/bot_trade/tools/monitor_manager.py
+++ b/bot_trade/tools/monitor_manager.py
@@ -33,7 +33,10 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         root = Path(ns.base).resolve() if ns.base else get_root()
-        reports_root = Path(DEFAULT_REPORTS_DIR) / "PPO"
+        reports_root = (
+            Path(ns.base).resolve() / "reports" if ns.base else Path(DEFAULT_REPORTS_DIR)
+        )
+        reports_root = reports_root / "PPO"
         run_id = ns.run_id
         if run_id in {None, "latest", "", "last"}:
             run_id = latest_run(ns.symbol, ns.frame, reports_root)


### PR DESCRIPTION
## Summary
- ensure headless helper prints a single `[HEADLESS] backend=Agg` line per CLI
- expose `eval_max_drawdown` in eval_run `[POSTRUN]` output
- harden `--run-id latest` guards for export, eval, and monitor tools

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m bot_trade.train_rl --algorithm PPO --symbol BTCUSDT --frame 1m --device cpu --n-envs 1 --n-steps 32 --batch-size 32 --total-steps 64 --headless --allow-synth --data-dir data_ready`
- `python -m bot_trade.tools.monitor_manager --symbol FAKE --frame 1m --run-id latest; test $? -eq 2 && echo EXIT_CODE_2`
- `python -m bot_trade.tools.export_charts --symbol FAKE --frame 1m --run-id latest; test $? -eq 2 && echo EXIT_CODE_2`
- `python -m bot_trade.tools.eval_run --symbol FAKE --frame 1m --run-id latest; test $? -eq 2 && echo EXIT_CODE_2`
- `python -m bot_trade.tools.eval_run --symbol BTCUSDT --frame 1m --run-id latest`


------
https://chatgpt.com/codex/tasks/task_b_68b768eefd04832db56949e6afdd279e