### PR TITLE
Refine evaluation outputs and lazy algo registry

### DIFF
--- a/CHANGE_NOTES.md
+++ b/CHANGE_NOTES.md
@@ -309,3 +309,11 @@ Risks/Migration: callers importing from old locations must switch to canonical m
 - **Rationale**: ensure single `[HEADLESS] backend=Agg` notice per CLI, expose `eval_max_drawdown` on `[POSTRUN]`, and harden `--run-id latest` guards across export/eval/monitor tools.
 - **Risks**: base path overrides may diverge from `BOT_REPORTS_DIR`.
 - **Test Steps**: `python -m py_compile $(git ls-files '*.py')`; synthetic run `python -m bot_trade.tools.gen_synth_data --symbol BTCUSDT --frame 1m --out data_ready`; `python -m bot_trade.train_rl --algorithm PPO --symbol BTCUSDT --frame 1m --device cpu --n-envs 1 --n-steps 32 --batch-size 32 --total-steps 64 --headless --allow-synth --data-dir data_ready`; missing-run guards `python -m bot_trade.tools.monitor_manager --symbol FAKE --frame 1m --run-id latest; test $? -eq 2 && echo EXIT_CODE_2`; same for `export_charts` and `eval_run`; evaluation `python -m bot_trade.tools.eval_run --symbol BTCUSDT --frame 1m --run-id latest`.
+
+## Developer Notes — 2025-09-02 22:30:40 UTC
+- headless notice confined to module `main` ensuring a single `[HEADLESS] backend=Agg` line per CLI.
+- strict `[LATEST] none` guard (exit code 2) retained across export/monitor/eval tools.
+- `[POSTRUN]` lines now include `algorithm`, `eval_win_rate`, `eval_sharpe`, and `eval_max_drawdown`.
+- evaluation suite refined: metrics, walk-forward, and tearsheet utilities integrated through `tools.eval_run`.
+- RL algorithm registry uses lazy imports; off-policy stubs validate Box spaces and emit clear skip notices.
+- migration: callers continue using `--algorithm` for `train_rl`; TD3/TQC remain stubs exiting early.

--- a/bot_trade/tools/eval_run.py
+++ b/bot_trade/tools/eval_run.py
@@ -134,10 +134,9 @@ def main(argv: list[str] | None = None) -> int:
     def _fmt(v: Any) -> str:
         return f"{v:.3f}" if isinstance(v, (int, float)) and v is not None else "null"
 
-    print(
-        "[EVAL] run_id=%s metrics={win_rate:%s, sharpe:%s, sortino:%s, calmar:%s, max_drawdown:%s, turnover:%s, avg_trade_pnl:%s, slippage_proxy:%s} out=%s"
+    metrics_part = (
+        "{win_rate:%s, sharpe:%s, sortino:%s, calmar:%s, max_drawdown:%s, turnover:%s, avg_trade_pnl:%s, slippage_proxy:%s}"
         % (
-            run_id,
             _fmt(summary.get("win_rate")),
             _fmt(summary.get("sharpe")),
             _fmt(summary.get("sortino")),
@@ -146,8 +145,10 @@ def main(argv: list[str] | None = None) -> int:
             _fmt(summary.get("turnover")),
             _fmt(summary.get("avg_trade_pnl")),
             _fmt(summary.get("slippage_proxy")),
-            out_dir.resolve(),
         )
+    )
+    print(
+        f"[EVAL] symbol={args.symbol} frame={args.frame} run_id={run_id} metrics={metrics_part}"
     )
 
     if args.wfa_splits:
@@ -168,9 +169,10 @@ def main(argv: list[str] | None = None) -> int:
         print(f"[TEARSHEET] out={ts_path.resolve()}")
 
     print(
-        "[POSTRUN] run_id=%s eval_win_rate=%s eval_sharpe=%s eval_max_drawdown=%s"
+        "[POSTRUN] run_id=%s algorithm=%s eval_win_rate=%s eval_sharpe=%s eval_max_drawdown=%s"
         % (
             run_id,
+            rp.algo,
             _fmt(summary.get("win_rate")),
             _fmt(summary.get("sharpe")),
             _fmt(summary.get("max_drawdown")),


### PR DESCRIPTION
## Summary
- ensure eval_run prints metrics with symbol/frame and final POSTRUN includes algorithm
- move PPO/SAC imports into builders and add Box-space guards for off-policy stubs
- record developer notes for headless notice, latest guard, and complete POSTRUN metrics

## Testing
- `python -m py_compile $(git ls-files 'bot_trade/**/*.py' 'bot_trade/*.py')`
- `python -m bot_trade.tools.gen_synth_data --symbol BTCUSDT --frame 1m --out data_ready`
- `python -m bot_trade.train_rl --symbol BTCUSDT --frame 1m --device cpu --n-envs 1 --n-steps 64 --batch-size 64 --total-steps 128 --headless --allow-synth --data-dir data_ready --no-monitor`
- `python -m bot_trade.tools.export_charts --symbol BTCUSDT --frame 1m --run-id latest --debug-export`
- `python -m bot_trade.tools.monitor_manager --symbol BTCUSDT --frame 1m --run-id latest --debug-export`
- `python -m bot_trade.tools.eval_run --symbol BTCUSDT --frame 1m --run-id latest --tearsheet`
- `python -m bot_trade.eval.tearsheet --symbol BTCUSDT --frame 1m --run-id latest`
- `python -m bot_trade.tools.export_charts --symbol FAKE --frame 1m --run-id latest ; echo EXIT:$?`
- `python -m bot_trade.tools.monitor_manager --symbol FAKE --frame 1m --run-id latest ; echo EXIT:$?`
- `python -m bot_trade.tools.eval_run --symbol FAKE --frame 1m --run-id latest ; echo EXIT:$?`


------
https://chatgpt.com/codex/tasks/task_b_68b76f102b74832d85b39845cd140c9c