### PR TITLE
feat: expand evaluation suite with equity helpers and KB metrics

### DIFF
--- a/CHANGE_NOTES.md
+++ b/CHANGE_NOTES.md
@@ -317,3 +317,16 @@ Risks/Migration: callers importing from old locations must switch to canonical m
 - evaluation suite refined: metrics, walk-forward, and tearsheet utilities integrated through `tools.eval_run`.
 - RL algorithm registry uses lazy imports; off-policy stubs validate Box spaces and emit clear skip notices.
 - migration: callers continue using `--algorithm` for `train_rl`; TD3/TQC remain stubs exiting early.
+
+## 2025-09-02
+- **Files**: `bot_trade/eval/metrics.py`, `bot_trade/eval/equity.py`, `bot_trade/eval/walk_forward.py`, `bot_trade/tools/eval_run.py`, `bot_trade/tools/kb_writer.py`, `bot_trade/train_rl.py`, `CHANGE_NOTES.md`, `DEV_NOTES.md`
+- **Rationale**: expand evaluation suite with equity helpers, aggregated metrics, walk-forward summaries, KB schema updates and canonical chart/eval prints.
+- **Risks**: walk-forward may yield empty placeholders on tiny datasets; downstream consumers must handle new KB fields.
+- **Test Steps**: `python -m py_compile $(git ls-files 'bot_trade/**/*.py' 'bot_trade/*.py')`; synthetic run + eval sequence as in verification snippet.
+
+## Developer Notes — 2025-09-02 22:47:38 UTC
+- headless single-notice upheld across all CLIs.
+- latest guards emit `[LATEST] none` with exit 2 when runs missing.
+- `[POSTRUN]` lines report algorithm, win rate, sharpe and max drawdown.
+- evaluation modules: `equity.build_equity_drawdown`, `metrics.compute_all`, walk-forward summaries.
+- migration: KB entries now include `sortino`, `calmar` and `images_list`; update parsers accordingly.

--- a/DEV_NOTES.md
+++ b/DEV_NOTES.md
@@ -190,3 +190,10 @@ that direct execution (`python tools/export_charts.py`) still works if needed.
 - Risks: base-directory overrides may still misalign with `BOT_REPORTS_DIR`.
 - Migration Steps: none; CLIs remain unchanged but consumers should expect updated headless line and POSTRUN metrics.
 - Next Actions: unify path resolution for custom report roots.
+
+## Developer Notes — 2025-09-02 22:47:38 UTC (Eval suite refresh)
+- What: added equity/drawdown helpers, metric aggregator, walk-forward summary exports, KB schema (sortino/calmar/images_list), and canonical chart/eval print flow.
+- Why: consolidate evaluation logic and enrich knowledge base context.
+- Risks: walk-forward outputs may be empty on small logs; downstream parsers must handle new KB fields.
+- Migration Steps: regenerate eval artifacts; update KB consumers for added fields.
+- Next Actions: broaden regime metrics and refine WFA robustness.

--- a/bot_trade/eval/equity.py
+++ b/bot_trade/eval/equity.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+"""Helpers for building equity and drawdown series."""
+
+from pathlib import Path
+from typing import Optional, Dict, Any, Tuple
+
+import pandas as pd
+
+from .utils import load_returns
+from .metrics import equity_from_rewards
+
+
+def build_equity_drawdown(
+    log_dir: Path,
+    cfg: Optional[Dict[str, Any]] = None,
+    window: Optional[int] = None,
+    fill_value: float = 0.0,
+) -> Tuple[pd.Series, pd.Series]:
+    """Return equity and drawdown series from ``log_dir``.
+
+    ``window`` limits the number of return rows considered. Missing values
+    are filled using ``fill_value``. ``cfg`` may include a starting equity via
+    ``{"start": float}"`.
+    """
+
+    returns = load_returns(Path(log_dir))
+    if window is not None:
+        returns = returns.tail(int(window))
+    returns = returns.fillna(fill_value)
+    rewards_df = returns.to_frame(name="reward")
+    equity = equity_from_rewards(rewards_df, cfg)
+    drawdown = (
+        equity / equity.cummax() - 1 if not equity.empty else pd.Series(dtype=float)
+    )
+    return equity, drawdown

--- a/bot_trade/eval/tearsheet.py
+++ b/bot_trade/eval/tearsheet.py
@@ -34,7 +34,7 @@ def generate_tearsheet(rp, pdf: bool = False) -> Path:
             summary = json.loads(s_path.read_text(encoding="utf-8"))
         except Exception:
             summary = {}
-    wfa_path = perf / "wfa.json"
+    wfa_path = perf / "wfa_summary.json"
     if wfa_path.exists():
         try:
             wfa = json.loads(wfa_path.read_text(encoding="utf-8"))

--- a/bot_trade/eval/walk_forward.py
+++ b/bot_trade/eval/walk_forward.py
@@ -5,7 +5,7 @@ import sys
 from pathlib import Path
 from typing import Iterator, Tuple, Dict, Any, TYPE_CHECKING
 
-from bot_trade.tools.atomic_io import write_json
+from bot_trade.tools.atomic_io import write_json, write_text
 
 if TYPE_CHECKING:  # pragma: no cover
     import pandas as pd
@@ -115,10 +115,18 @@ def main(argv: list[str] | None = None) -> int:
     except Exception as exc:  # pragma: no cover
         print(f"[ERROR] {exc}", file=sys.stderr)
         return 1
-    out_path = rp.performance_dir / "wfa.json"
-    write_json(out_path, result)
+    json_path = rp.performance_dir / "wfa_summary.json"
+    write_json(json_path, result)
+    csv_path = rp.performance_dir / "wfa_summary.csv"
+    try:
+        import pandas as pd
+
+        df = pd.DataFrame(result.get("folds", []))
+        write_text(csv_path, df.to_csv(index=False) if not df.empty else "")
+    except Exception:
+        write_text(csv_path, "")
     print(
-        f"[WFA] run_id={run_id} splits={ns.splits} embargo={ns.embargo} out={out_path.resolve()}"
+        f"[WFA] run_id={run_id} splits={ns.splits} embargo={ns.embargo} out={json_path.resolve()}"
     )
     return 0
 

--- a/bot_trade/tools/kb_writer.py
+++ b/bot_trade/tools/kb_writer.py
@@ -22,6 +22,7 @@ KB_DEFAULTS = {
     "algorithm": None,
     "ts": None,
     "images": 0,
+    "images_list": [],
     "rows_reward": 0,
     "rows_step": 0,
     "rows_train": 0,
@@ -36,6 +37,8 @@ KB_DEFAULTS = {
     "eval": {
         "win_rate": None,
         "sharpe": None,
+        "sortino": None,
+        "calmar": None,
         "max_drawdown": None,
         "avg_trade_pnl": None,
         "turnover": None,

--- a/bot_trade/train_rl.py
+++ b/bot_trade/train_rl.py
@@ -109,8 +109,8 @@ def _postrun_summary(paths, meta):
     eval_summary: dict[str, Any] = meta.get("synthetic_eval") or {}
     if not eval_summary:
         try:
-            eval_summary = evaluate_for_run(rp, episodes=int(meta.get("eval_episodes", 3)))
-            logger.info("[EVAL] done episodes=%s", meta.get("eval_episodes", 3))
+            eval_summary = evaluate_for_run(rp.symbol, rp.frame, run_id=rp.run_id)
+            logger.info("[EVAL] done")
         except Exception as e:
             logger.warning("[EVAL] failed err=%s", e)
             eval_summary = {}
@@ -134,6 +134,7 @@ def _postrun_summary(paths, meta):
             img_count += 1
         except Exception:
             pass
+    images_list = [p.name for p in charts_dir.glob("*.png") if p.is_file() and not p.is_symlink()]
     rows_reward = row_counts.get("reward", 0)
     rows_step = row_counts.get("step", 0)
     rows_train = row_counts.get("train", 0)
@@ -187,6 +188,8 @@ def _postrun_summary(paths, meta):
     eval_entry = {
         "win_rate": eval_summary.get("win_rate"),
         "sharpe": eval_summary.get("sharpe"),
+        "sortino": eval_summary.get("sortino"),
+        "calmar": eval_summary.get("calmar"),
         "max_drawdown": eval_summary.get("max_drawdown"),
         "avg_trade_pnl": eval_summary.get("avg_trade_pnl"),
         "turnover": eval_summary.get("turnover"),
@@ -208,6 +211,7 @@ def _postrun_summary(paths, meta):
             "algorithm": algo,
             "ts": dt.datetime.utcnow().isoformat(),
             "images": img_count,
+            "images_list": images_list,
             "rows_reward": rows_reward,
             "rows_step": rows_step,
             "rows_train": rows_train,


### PR DESCRIPTION
## Summary
- add stable metric aggregator and equity/drawdown builder
- emit walk-forward summaries and standard chart/eval prints
- extend knowledge base with sortino, calmar and image listing

## Testing
- `python -m py_compile $(git ls-files 'bot_trade/**/*.py' 'bot_trade/*.py')`
- `python -m bot_trade.tools.gen_synth_data --symbol BTCUSDT --frame 1m --out data_ready`
- `python -m bot_trade.train_rl --algorithm PPO --symbol BTCUSDT --frame 1m --device cpu --n-envs 1 --n-steps 64 --batch-size 64 --total-steps 128 --headless --allow-synth --data-dir data_ready --no-monitor`
- `python -m bot_trade.tools.export_charts --symbol BTCUSDT --frame 1m --run-id latest --debug-export`
- `python -m bot_trade.tools.monitor_manager --symbol BTCUSDT --frame 1m --run-id latest --debug-export`
- `python -m bot_trade.tools.eval_run --symbol BTCUSDT --frame 1m --run-id latest --tearsheet`
- `python -m bot_trade.eval.tearsheet --symbol BTCUSDT --frame 1m --run-id latest`
- `python -m bot_trade.tools.export_charts --symbol FAKE --frame 1m --run-id latest ; test $? -eq 2 && echo EXIT_CODE_2`
- `python -m bot_trade.tools.monitor_manager --symbol FAKE --frame 1m --run-id latest ; test $? -eq 2 && echo EXIT_CODE_2`
- `python -m bot_trade.tools.eval_run --symbol FAKE --frame 1m --run-id latest ; test $? -eq 2 && echo EXIT_CODE_2`


------
https://chatgpt.com/codex/tasks/task_b_68b77341a01c832da8a5a5ecfe33f3e9