### PR TITLE
Consolidate evaluation suite and headless notices

### DIFF
--- a/CHANGE_NOTES.md
+++ b/CHANGE_NOTES.md
@@ -330,3 +330,18 @@ Risks/Migration: callers importing from old locations must switch to canonical m
 - `[POSTRUN]` lines report algorithm, win rate, sharpe and max drawdown.
 - evaluation modules: `equity.build_equity_drawdown`, `metrics.compute_all`, walk-forward summaries.
 - migration: KB entries now include `sortino`, `calmar` and `images_list`; update parsers accordingly.
+
+## 2025-09-02
+- **Files**: bot_trade/tools/export_charts.py, bot_trade/tools/monitor_manager.py, bot_trade/tools/eval_run.py, bot_trade/eval/metrics.py, bot_trade/eval/tearsheet.py, DEV_NOTES.md, CHANGE_NOTES.md
+- **Rationale**: unify headless prints, enforce latest guards, consolidate evaluation suite and enrich knowledge base entries.
+- **Risks**: downstream parsers may rely on prior metric ordering or KB fields.
+- **Test Steps**: `python -m py_compile bot_trade/**/*.py bot_trade/*.py`; run synth training and evaluation commands from quick verification.
+
+## Developer Notes — 2025-09-02 23:16:24 UTC
+- Unified headless single-notice in CLIs
+- Strict latest guards (exit=2)
+- Canonical [EVAL] then [POSTRUN] (includes algorithm & eval_max_drawdown)
+- Evaluation suite: metrics/equity/walk_forward/tearsheet
+- KB enrichment: metrics+images, duplicate run_id guard
+- Placeholders for sparse data; all outputs atomic
+- Migration notes for older scripts parsing POSTRUN

--- a/DEV_NOTES.md
+++ b/DEV_NOTES.md
@@ -197,3 +197,10 @@ that direct execution (`python tools/export_charts.py`) still works if needed.
 - Risks: walk-forward outputs may be empty on small logs; downstream parsers must handle new KB fields.
 - Migration Steps: regenerate eval artifacts; update KB consumers for added fields.
 - Next Actions: broaden regime metrics and refine WFA robustness.
+
+## Developer Notes — 2025-09-02 23:16:24 UTC (Eval suite consolidation)
+- What: localized `[HEADLESS]` prints in export/eval/monitor CLIs, enriched KB entries with metrics and image names, moved `[TEARSHEET]` prints into generator, and switched metrics.compute_all to equity-based inputs.
+- Why: ensure single headless notice per CLI, avoid duplicate KB records, and finalize evaluation artifact workflow.
+- Risks: downstream parsers may expect previous metric order or tearsheet prints from callers.
+- Migration Steps: adjust scripts to new `[EVAL]` metric order and rely on `eval.tearsheet.generate_tearsheet` for its notice.
+- Next Actions: extend metrics and regime analytics across evaluation utilities.

--- a/bot_trade/eval/tearsheet.py
+++ b/bot_trade/eval/tearsheet.py
@@ -165,6 +165,7 @@ def generate_tearsheet(rp, pdf: bool = False) -> Path:
                 write_pdf_atomic(pdf_path, pdf_bytes)
         except Exception:
             pass
+    print(f"[TEARSHEET] out={html_path.resolve()}")
     return html_path
 
 
@@ -190,11 +191,10 @@ def main(argv: list[str] | None = None) -> int:
         run_id = rid
     rp = RunPaths(ns.symbol, ns.frame, run_id)
     try:
-        out = generate_tearsheet(rp, pdf=ns.pdf)
+        generate_tearsheet(rp, pdf=ns.pdf)
     except Exception as exc:  # pragma: no cover
         print(f"[ERROR] {exc}", file=sys.stderr)
         return 1
-    print(f"[TEARSHEET] out={out.resolve()}")
     return 0
 
 

--- a/bot_trade/tools/monitor_manager.py
+++ b/bot_trade/tools/monitor_manager.py
@@ -9,11 +9,17 @@ from pathlib import Path
 from bot_trade.config.rl_paths import RunPaths, get_root, DEFAULT_REPORTS_DIR
 from bot_trade.tools.latest import latest_run
 from bot_trade.tools import export_charts
-from bot_trade.tools._headless import ensure_headless_once
 
 
 def main(argv: list[str] | None = None) -> int:
-    ensure_headless_once("monitor_manager")
+    def _set_headless() -> None:
+        import matplotlib
+
+        if matplotlib.get_backend().lower() != "agg":
+            matplotlib.use("Agg")
+        print("[HEADLESS] backend=Agg")
+
+    _set_headless()
     ap = argparse.ArgumentParser(
         description="Generate charts for a finished training run",
         epilog=(
@@ -62,8 +68,7 @@ def main(argv: list[str] | None = None) -> int:
         if ns.tearsheet:
             from bot_trade.eval.tearsheet import generate_tearsheet
 
-            ts_path = generate_tearsheet(rp, pdf=ns.pdf)
-            print(f"[TEARSHEET] out={ts_path.resolve()}")
+            generate_tearsheet(rp, pdf=ns.pdf)
         return 0 if images > 0 else 2
     except Exception as exc:  # pragma: no cover
         print(f"[ERROR] {exc}", file=sys.stderr)


### PR DESCRIPTION
## Summary
- move headless backend print into export_charts, monitor_manager and eval_run CLIs
- compute metrics from equity series and enrich knowledge base with images and regime distribution
- centralize [TEARSHEET] output and keep canonical [EVAL] then [POSTRUN]

## Testing
- `python -m py_compile $(git ls-files 'bot_trade/**/*.py' 'bot_trade/*.py')`
- `python -m bot_trade.tools.gen_synth_data --symbol BTCUSDT --frame 1m --out data_ready`
- `python -m bot_trade.train_rl --algorithm PPO --symbol BTCUSDT --frame 1m --device cpu --n-envs 1 --n-steps 64 --batch-size 64 --total-steps 128 --headless --allow-synth --data-dir data_ready --no-monitor`
- `python -m bot_trade.tools.export_charts   --symbol BTCUSDT --frame 1m --run-id latest --debug-export`
- `python -m bot_trade.tools.monitor_manager --symbol BTCUSDT --frame 1m --run-id latest --debug-export`
- `python -m bot_trade.tools.eval_run  --symbol BTCUSDT --frame 1m --run-id latest --tearsheet`
- `python -m bot_trade.eval.tearsheet  --symbol BTCUSDT --frame 1m --run-id latest`
- `python -m bot_trade.tools.export_charts   --symbol FAKE --frame 1m --run-id latest ; test $? -eq 2`
- `python -m bot_trade.tools.monitor_manager --symbol FAKE --frame 1m --run-id latest ; test $? -eq 2`
- `python -m bot_trade.tools.eval_run        --symbol FAKE --frame 1m --run-id latest ; test $? -eq 2`


------
https://chatgpt.com/codex/tasks/task_b_68b779887620832dabcd2fe09c79472c