### PR TITLE
Improve policy_kwargs parsing and env logging

### DIFF
--- a/CHANGE_NOTES.md
+++ b/CHANGE_NOTES.md
@@ -316,6 +316,12 @@ Risks/Migration: callers importing from old locations must switch to canonical m
 - **Risks**: base path overrides may diverge from `BOT_REPORTS_DIR`.
 - **Test Steps**: `python -m py_compile $(git ls-files '*.py')`; synthetic run `python -m bot_trade.tools.gen_synth_data --symbol BTCUSDT --frame 1m --out data_ready`; `python -m bot_trade.train_rl --algorithm PPO --symbol BTCUSDT --frame 1m --device cpu --n-envs 1 --n-steps 32 --batch-size 32 --total-steps 64 --headless --allow-synth --data-dir data_ready`; missing-run guards `python -m bot_trade.tools.monitor_manager --symbol FAKE --frame 1m --run-id latest; test $? -eq 2 && echo EXIT_CODE_2`; same for `export_charts` and `eval_run`; evaluation `python -m bot_trade.tools.eval_run --symbol BTCUSDT --frame 1m --run-id latest`.
 
+## 2025-10-07
+- **Files**: `bot_trade/env/trading_env_continuous.py`, `bot_trade/config/rl_args.py`, `bot_trade/config/rl_builders.py`, `bot_trade/tools/kb_writer.py`, `DEV_NOTES.md`, `CHANGE_NOTES.md`
+- **Rationale**: single `[ENV]` notice for continuous env, pass-through `policy_kwargs` with JSON parsing and unused-key warnings, standardized TQC guard, KB newline assurance and condensed `policy_kwargs`, and updated `--continuous-env` help.
+- **Risks**: unused key detection is shallow; KB newline fix may touch large files.
+- **Test Steps**: `python -m py_compile bot_trade/env/trading_env_continuous.py bot_trade/config/rl_args.py bot_trade/config/rl_builders.py bot_trade/tools/kb_writer.py`; discrete guard `python -m bot_trade.train_rl --algorithm SAC --symbol BTCUSDT --frame 1m --device cpu --n-envs 1 --n-steps 32 --batch-size 64 --total-steps 64 --headless --allow-synth --data-dir data_ready --no-monitor`; continuous smoke `python -m bot_trade.train_rl --algorithm SAC --continuous-env --symbol BTCUSDT --frame 1m --device cpu --n-envs 1 --n-steps 64 --batch-size 64 --total-steps 256 --headless --allow-synth --data-dir data_ready --no-monitor`; policy_kwargs big nets snippet; TQC dependency guard snippet.
+
 ## Developer Notes — 2025-09-02 22:30:40 UTC
 - headless notice confined to module `main` ensuring a single `[HEADLESS] backend=Agg` line per CLI.
 - strict `[LATEST] none` guard (exit code 2) retained across export/monitor/eval tools.
@@ -358,3 +364,9 @@ Risks/Migration: callers importing from old locations must switch to canonical m
 - Enabled PPO→SAC warm-start (encoder-only, shape-checked) with single-line status
 - Fixed policy_kwargs passthrough; support dict or JSON string; recorded condensed policy_kwargs in algo_meta
 - Kept logging contracts, latest guard, and Evaluation Suite behavior unchanged; all outputs atomic
+
+## 2025-10-07
+- **Files**: bot_trade/env/trading_env_continuous.py, bot_trade/config/rl_builders.py, DEV_NOTES.md, CHANGE_NOTES.md
+- **Rationale**: confine continuous-env notice to factory and condense net_arch length in policy_kwargs metadata.
+- **Risks**: direct TradingEnvContinuous use skips [ENV] notice; truncated net_arch may hide details.
+- **Test Steps**: `python -m py_compile bot_trade/env/trading_env_continuous.py bot_trade/config/rl_builders.py`; discrete guard `python -m bot_trade.train_rl --algorithm SAC --symbol BTCUSDT --frame 1m --device cpu --n-envs 1 --n-steps 32 --batch-size 64 --total-steps 64 --headless --allow-synth --data-dir data_ready --no-monitor`; continuous smoke `python -m bot_trade.train_rl --algorithm SAC --continuous-env --symbol BTCUSDT --frame 1m --device cpu --n-envs 1 --n-steps 64 --batch-size 64 --total-steps 256 --headless --allow-synth --data-dir data_ready --no-monitor`; policy_kwargs snippet; TQC guard snippet.

--- a/DEV_NOTES.md
+++ b/DEV_NOTES.md
@@ -191,6 +191,20 @@ that direct execution (`python tools/export_charts.py`) still works if needed.
 - Migration Steps: none; CLIs remain unchanged but consumers should expect updated headless line and POSTRUN metrics.
 - Next Actions: unify path resolution for custom report roots.
 
+## Developer Notes — 2025-10-07
+- What: single `[ENV]` notice on continuous env instantiation, policy_kwargs parser with JSON support, unused-key and invalid-JSON warnings, standardized TQC guard, KB newline enforcement and condensed policy_kwargs metadata.
+- Why: tighten logging contracts and ensure KB entries capture algorithm config succinctly.
+- Risks: unused-key detection is shallow; newline fix touches entire KB file on very large runs.
+- Migration: none; pass policy_kwargs as dict/JSON; install `sb3-contrib` for TQC.
+- Next Actions: expand policy_kwargs validation depth and monitor KB file growth.
+
+## Developer Notes — 2025-10-07T00:00:01Z (env notice factory & net_arch meta)
+- What: moved continuous env notice to builder factory and added net_arch length hint in policy_kwargs metadata.
+- Why: keep imports quiet and summarize large architectures in KB/metadata.
+- Risks: direct `TradingEnvContinuous` usage skips `[ENV]` print; truncated lists may omit details.
+- Migration Steps: call `ensure_env_notice()` when instantiating `TradingEnvContinuous` outside factories.
+- Next Actions: watch for missed notices and refine metadata compaction.
+
 ## Developer Notes — 2025-09-02 22:47:38 UTC (Eval suite refresh)
 - What: added equity/drawdown helpers, metric aggregator, walk-forward summary exports, KB schema (sortino/calmar/images_list), and canonical chart/eval print flow.
 - Why: consolidate evaluation logic and enrich knowledge base context.

--- a/bot_trade/config/rl_args.py
+++ b/bot_trade/config/rl_args.py
@@ -249,7 +249,11 @@ def parse_args():
         default="PPO",
         help="Choose RL algorithm (TD3/TQC stubs; default PPO unless config overrides)",
     )
-    ap.add_argument("--continuous-env", action="store_true", help="Use continuous trading environment")
+    ap.add_argument(
+        "--continuous-env",
+        action="store_true",
+        help="Use Box(-1,1) action space; enables SAC/TD3/TQC (backward compatible).",
+    )
     ap.add_argument("--buffer-size", type=int)
     ap.add_argument("--learning-starts", type=int)
     ap.add_argument("--train-freq", type=int)

--- a/bot_trade/env/trading_env_continuous.py
+++ b/bot_trade/env/trading_env_continuous.py
@@ -3,6 +3,17 @@ import numpy as np
 from gymnasium import spaces
 from bot_trade.config.env_trading import TradingEnv
 
+_env_notice_printed = False
+
+
+def ensure_env_notice() -> None:
+    """Print the continuous env notice once per process."""
+    global _env_notice_printed
+    if not _env_notice_printed:
+        print("[ENV] action_space=Box(-1.0,1.0) dims=1")
+        _env_notice_printed = True
+
+
 class TradingEnvContinuous(TradingEnv):
     """Continuous-action variant of TradingEnv.
 
@@ -13,7 +24,6 @@ class TradingEnvContinuous(TradingEnv):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.action_space = spaces.Box(low=-1.0, high=1.0, shape=(1,), dtype=np.float32)
-        print("[ENV] action_space=Box(-1.0,1.0) dims=1")
 
     def step(self, action):
         import numpy as _np


### PR DESCRIPTION
## Summary
- ensure continuous env notice is emitted by factory, avoiding import-time prints
- include net_arch length hint when recording policy_kwargs

## Testing
- `python -m py_compile bot_trade/env/trading_env_continuous.py bot_trade/config/rl_builders.py`
- `python -m bot_trade.train_rl --algorithm SAC --symbol BTCUSDT --frame 1m --device cpu --n-envs 1 --n-steps 32 --batch-size 64 --total-steps 64 --headless --allow-synth --data-dir data_ready --no-monitor`
- `python -m bot_trade.train_rl --algorithm SAC --continuous-env --symbol BTCUSDT --frame 1m --device cpu --n-envs 1 --n-steps 64 --batch-size 64 --total-steps 256 --headless --allow-synth --data-dir data_ready --no-monitor`
- `python - <<'PY'
import json, gymnasium as gym
from types import SimpleNamespace
from bot_trade.config.rl_builders import build_algorithm
env = gym.make('Pendulum-v1')
pk = {"net_arch":[1024,1024,512,512,256,256], "activation_fn":"ReLU", "ortho_init":False}
args = SimpleNamespace(policy_kwargs=json.dumps(pk), device_str='cpu', seed=0, symbol='TEST', frame='1m')
model, meta = build_algorithm('SAC', env, args, 0)
print("[META] policy_kwargs", meta.get("policy_kwargs"))
PY`
- `python - <<'PY'
from types import SimpleNamespace
import gymnasium as gym
from bot_trade.config.rl_builders import build_algorithm
env = gym.make('Pendulum-v1')
args = SimpleNamespace(policy_kwargs={}, device_str='cpu', seed=0, symbol='TEST', frame='1m')
try:
  build_algorithm('TQC', env, args, 0)
except SystemExit as e:
  print("exit", e.code)
PY`


------
https://chatgpt.com/codex/tasks/task_b_68b78ddadb7c832db8a3cb8f4aedda46