### PR TITLE
feat: add reward registry and adaptive regime control

### DIFF
--- a/CHANGE_NOTES.md
+++ b/CHANGE_NOTES.md
@@ -364,3 +364,17 @@ Risks/Migration: callers importing from old locations must switch to canonical m
 - Enabled PPO→SAC warm-start (encoder-only, shape-checked) with single-line status
 - Fixed policy_kwargs passthrough; support dict or JSON string; recorded condensed policy_kwargs in algo_meta
 - Kept logging contracts, latest guard, and Evaluation Suite behavior unchanged; all outputs atomic
+
+## Developer Notes — 2025-09-03 01:15:11 UTC
+- What: Added YAML-driven rewards registry with clamps, regime detector with JSONL logging, adaptive controller applying reward/risk deltas, regimes.png exports, dev_checks updates, KB log counts, and CLI flags for reward/adaptive specs.
+- Why: enable configurable reward shaping and regime-aware risk adjustments while preserving existing interfaces.
+- Risks: misconfigured specs may yield silent clamping or no adaptive triggers; reward registry not yet fully integrated with environment.
+- Migration: provide --reward-spec and --adaptive-spec paths (defaults available), parse regime/adaptive log counts in KB consumers.
+- Next Actions: expand reward terms, tighten regime thresholds, and link registry outputs directly to env rewards.
+
+## Developer Notes — 2025-09-03 01:42:15 UTC
+- What: Debounced `[ADAPT]` logging per `{regime, window_id}`, seeded `RegimeDetector`, sanitized reward term handling, nested KB log counts, and enforced `regimes.png` DPI/size checks.
+- Why: reduce duplicate adaptive prints, ensure deterministic regime analysis and numeric stability, and satisfy artifact requirements.
+- Risks: adaptive deltas skipped if controller invoked repeatedly within same window; dev checks now fail on low-DPI regime charts.
+- Migration: consumers must read `logs.regime_log_count`/`logs.adaptive_log_count` instead of old flat fields.
+- Next Actions: monitor regime transitions in extended runs and refine detector thresholds.

--- a/bot_trade/config/rl_args.py
+++ b/bot_trade/config/rl_args.py
@@ -236,6 +236,8 @@ def parse_args():
     ap.add_argument("--regime-aware", action="store_true", help="Enable regime-aware adjustments")
     ap.add_argument("--regime-window", type=int, default=0, help="Steps between regime checks")
     ap.add_argument("--regime-log", action=argparse.BooleanOptionalAction, default=None, help="Log adaptive regime adjustments")
+    ap.add_argument("--reward-spec", type=str, default=None, help="Reward spec YAML path")
+    ap.add_argument("--adaptive-spec", type=str, default=None, help="Adaptive controller YAML path")
     ap.add_argument("--strategy-failure", action=argparse.BooleanOptionalAction, default=None, help="Enable strategy failure policy")
     ap.add_argument("--safety-every", type=int, default=1, help="Check safety every N steps")
     ap.add_argument("--loss-streak", type=int)
@@ -277,6 +279,10 @@ def parse_args():
         name = item[2:].split("=", 1)[0].replace("-", "_")
         specified.add(name)
     args._specified = specified
+    if getattr(args, "adaptive_spec", None):
+        args.regime_aware = True
+        if args.regime_log is None:
+            args.regime_log = True
     if args.regime_log is None:
         args.regime_log = bool(args.regime_aware)
     level_name = str(getattr(args, "log_level", "INFO")).upper()

--- a/bot_trade/env/trading_env_continuous.py
+++ b/bot_trade/env/trading_env_continuous.py
@@ -182,6 +182,10 @@ class TradingEnvContinuous(TradingEnv):
                 "risk_threshold": thr,
             })
         info["reward_components"] = comps
+        try:
+            info["regime"] = getattr(self, "current_regime", "unknown")
+        except Exception:
+            info["regime"] = "unknown"
         self._log_decision({
             "step": int(self.steps),
             "ptr": int(self.ptr),

--- a/bot_trade/strat/adaptive_controller.py
+++ b/bot_trade/strat/adaptive_controller.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
 import datetime as dt
-import logging
 from collections import Counter
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-from .regime import detect_regime
+from .regime import RegimeDetector
 from bot_trade.tools.atomic_io import append_jsonl
 
 
@@ -18,152 +17,115 @@ class AdaptiveController:
         cfg: Dict[str, Any],
         env: Optional[Any] = None,
         log_path: Optional[Path] = None,
+        regime_log_path: Optional[Path] = None,
     ) -> None:
         self.cfg = cfg or {}
         self.env = env
         self.log_path = Path(log_path) if log_path else None
-        self.warned = False
+        det_cfg = self.cfg.get("detector", {})
+        self.detector = RegimeDetector(det_cfg, regime_log_path, seed=det_cfg.get("seed"))
         self.last_regime = "unknown"
         self.dist: Counter[str] = Counter()
+        self._last_key: tuple[str, int] | None = None
 
-        # baselines
+        self.w_clamp = self.cfg.get("clamps", {}).get("reward_weight_delta", {})
+        self.b_clamp = self.cfg.get("clamps", {}).get("risk_bound_delta", {})
+
         rw = getattr(getattr(env, "reward_tracker", None), "w", None)
-        self.base_weights = tuple(rw) if rw else None
+        self.base_weights = list(rw) if rw else []
         re = getattr(env, "risk_engine", None)
-        ex = getattr(env, "exec_sim", None)
         self.base_bounds = {
-            "max_spread_bp": getattr(ex, "max_spread_bp", None),
-            "exposure_cap": getattr(re, "max_risk", None),
-            "freeze_after_losses": getattr(re, "freeze_limit", None),
+            "max_position": getattr(re, "max_units", None),
+            "max_leverage": getattr(re, "max_risk", None),
+            "trailing_dd_limit": getattr(re, "max_drawdown_stop", None),
         }
 
-    # ----------------------------------------------
+    # --------------------------------------------------------------
     def update(self, df_slice: Any) -> None:
-        info = detect_regime(df_slice, cfg=self.cfg)
+        info = self.detector.update(df_slice)
         regime = info.get("name", "unknown")
+        wid = int(info.get("window_id", 0))
         self.last_regime = regime
         self.dist[regime] += 1
-        if self.env is not None:
-            try:
-                setattr(self.env, "current_regime", regime)
-            except Exception:
-                pass
+        key = (regime, wid)
+        if regime != getattr(self, "_last_print_regime", None) and key != self._last_key:
+            mapping = (self.cfg.get("regime_rules") or {}).get(regime, {})
+            d_w = self._apply_reward_delta(mapping.get("reward_delta", {}))
+            d_r = self._apply_risk_delta(mapping.get("risk_clamp_delta", {}))
+            print(f"[ADAPT] regime={regime} dW={list(d_w.keys())} dRisk={list(d_r.keys())}")
+            if self.log_path:
+                rec = {
+                    "ts": dt.datetime.utcnow().isoformat(),
+                    "regime": regime,
+                    "window_id": wid,
+                    "dW": d_w,
+                    "dRisk": d_r,
+                }
+                try:
+                    append_jsonl(self.log_path, rec)
+                except Exception:
+                    pass
+            self._last_key = key
+            self._last_print_regime = regime
 
-        mapping = (self.cfg.get("mappings", {}) or {}).get(regime)
-        if not mapping:
-            if not self.warned and regime != "unknown":
-                logging.warning("[REGIME] no mapping for %s", regime)
-                self.warned = True
-            weights = {}
-            bounds = {}
-        else:
-            weights = mapping.get("reward_weights", {})
-            bounds = mapping.get("risk_bounds", {})
-        applied_w = self._apply_weights(weights)
-        applied_b = self._apply_bounds(bounds)
-        if self.log_path:
-            record = {
-                "ts": dt.datetime.utcnow().isoformat(),
-                "regime": regime,
-                "weights": applied_w,
-                "risk_bounds": applied_b,
-            }
-            try:
-                append_jsonl(self.log_path, record)
-            except Exception:
-                pass
+    # --------------------------------------------------------------
+    def _clamp(self, value: float, clamp: Dict[str, float]) -> float:
+        lo = float(clamp.get("min", float("-inf")))
+        hi = float(clamp.get("max", float("inf")))
+        return max(lo, min(value, hi))
 
-    # ----------------------------------------------
-    def _apply_weights(self, weights: Dict[str, Any]) -> Dict[str, Any]:
-        env = self.env
-        tracker = getattr(env, "reward_tracker", None)
-        if tracker is None:
+    def _apply_reward_delta(self, delta: Dict[str, float]) -> Dict[str, float]:
+        tracker = getattr(self.env, "reward_tracker", None)
+        if tracker is None or not self.base_weights:
             return {}
-        w = list(self.base_weights or getattr(tracker, "w", []))
-        if len(w) != 7:
-            return {}
-        applied = {
-            "dd_penalty": w[2],
-            "trend_bonus": w[3],
-            "holding_penalty": w[6],
+        w = list(self.base_weights)
+        mapping = {
+            "base_pnl": 0,
+            "risk_drawdown": 2,
+            "slippage_penalty": 5,
+            "inventory_penalty": 6,
         }
-        if weights:
-            if "dd_penalty" in weights:
-                try:
-                    val = self._clamp("dd_penalty", float(weights["dd_penalty"]), kind="weights")
-                    w[2] = val
-                    applied["dd_penalty"] = val
-                except Exception:
-                    if not self.warned:
-                        logging.warning("[REGIME] invalid dd_penalty")
-                        self.warned = True
-            if "trend_bonus" in weights:
-                try:
-                    val = self._clamp("trend_bonus", float(weights["trend_bonus"]), kind="weights")
-                    w[3] = val
-                    applied["trend_bonus"] = val
-                except Exception:
-                    if not self.warned:
-                        logging.warning("[REGIME] invalid trend_bonus")
-                        self.warned = True
-            if "holding_penalty" in weights:
-                try:
-                    val = self._clamp("holding_penalty", float(weights["holding_penalty"]), kind="weights")
-                    w[6] = val
-                    applied["holding_penalty"] = val
-                except Exception:
-                    if not self.warned:
-                        logging.warning("[REGIME] invalid holding_penalty")
-                        self.warned = True
-        tracker.w = tuple(w)
+        applied: Dict[str, float] = {}
+        for k, v in (delta or {}).items():
+            idx = mapping.get(k)
+            if idx is None or idx >= len(w):
+                continue
+            adj = self._clamp(float(v), self.w_clamp)
+            if adj == 0:
+                continue
+            w[idx] = float(w[idx]) + adj
+            applied[k] = adj
+        if applied:
+            tracker.w = tuple(w)
+            self.base_weights = w
         return applied
 
-    def _clamp(self, key: str, value: float, kind: str = "bounds") -> Optional[float]:
-        if kind == "bounds":
-            cfg = self.cfg.get("bounds", {}) or {}
-        else:
-            cfg = self.cfg.get("weight_limits", {}) or {}
-        lim = cfg.get(key, {})
-        lo = float(lim.get("min", float("-inf")))
-        hi = float(lim.get("max", float("inf")))
-        clamped = max(lo, min(value, hi))
-        if clamped != value and not self.warned:
-            logging.warning("[REGIME] %s=%s clamped to [%s,%s]", key, value, lo, hi)
-            self.warned = True
-        return clamped
-
-    def _apply_bounds(self, bounds: Dict[str, Any]) -> Dict[str, Any]:
-        env = self.env
-        re = getattr(env, "risk_engine", None)
-        ex = getattr(env, "exec_sim", None)
-        base = dict(self.base_bounds)
-        if bounds:
-            base.update(bounds)
-        applied: Dict[str, Any] = {}
-        if "max_spread_bp" in base and ex is not None:
-            try:
-                val = self._clamp("max_spread_bp", float(base["max_spread_bp"]))
-                ex.max_spread_bp = val
-                applied["max_spread_bp"] = val
-            except Exception:
-                pass
-        if "exposure_cap" in base and re is not None:
-            try:
-                val = self._clamp("exposure_cap", float(base["exposure_cap"]))
-                re.max_risk = val
-                applied["exposure_cap"] = val
-            except Exception:
-                pass
-        if "freeze_after_losses" in base and re is not None:
-            try:
-                val = self._clamp("freeze_after_losses", float(base["freeze_after_losses"]))
-                re.freeze_limit = int(val)
-                applied["freeze_after_losses"] = int(val)
-            except Exception:
-                pass
+    def _apply_risk_delta(self, delta: Dict[str, float]) -> Dict[str, float]:
+        re = getattr(self.env, "risk_engine", None)
+        if re is None:
+            return {}
+        applied: Dict[str, float] = {}
+        for k, v in (delta or {}).items():
+            if k not in self.base_bounds:
+                continue
+            base = self.base_bounds.get(k)
+            if base is None:
+                continue
+            adj = self._clamp(float(v), self.b_clamp)
+            if adj == 0:
+                continue
+            new_val = base + adj
+            if k == "max_position":
+                re.max_units = new_val
+            elif k == "max_leverage":
+                re.max_risk = new_val
+            elif k == "trailing_dd_limit":
+                re.max_drawdown_stop = new_val
+            applied[k] = adj
+            self.base_bounds[k] = new_val
         return applied
 
-    # ----------------------------------------------
+    # --------------------------------------------------------------
     def get_distribution(self) -> Dict[str, float]:
         total = sum(self.dist.values())
         if total == 0:

--- a/bot_trade/strat/regime.py
+++ b/bot_trade/strat/regime.py
@@ -113,3 +113,43 @@ def detect_regime(df_like: Any, *, cfg: Dict[str, Any]) -> Dict[str, Any]:
         regime = "range"
 
     return {"name": regime, "scores": scores, "ts": ts}
+
+from pathlib import Path
+from bot_trade.tools.atomic_io import append_jsonl
+
+
+class RegimeDetector:
+    """Incremental regime detector with optional JSONL logging."""
+
+    def __init__(
+        self,
+        cfg: Dict[str, Any] | None = None,
+        log_path: Path | None = None,
+        seed: int | None = 0,
+    ) -> None:
+        self.cfg = cfg or {}
+        self.log_path = Path(log_path) if log_path else None
+        self.rng = np.random.default_rng(seed)
+        self._wid = 0
+
+    def update(self, df_slice: Any) -> Dict[str, Any]:
+        info = detect_regime(df_slice, cfg=self.cfg)
+        try:
+            wid = int(len(df_slice))
+        except Exception:
+            wid = self._wid
+            self._wid += 1
+        info["window_id"] = wid
+        self._wid = wid
+        if self.log_path:
+            rec = {
+                "ts": info.get("ts"),
+                "regime": info.get("name"),
+                "features": info.get("scores", {}),
+                "window_id": info.get("window_id"),
+            }
+            try:
+                append_jsonl(self.log_path, rec)
+            except Exception:
+                pass
+        return info

--- a/bot_trade/strat/rewards_registry.py
+++ b/bot_trade/strat/rewards_registry.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import math
+from pathlib import Path
+from typing import Any, Callable, Dict, Mapping, Tuple
+
+import yaml
+
+# ---------------------------------------------------------------------------
+# Reward term registry
+# ---------------------------------------------------------------------------
+
+REGISTRY: Dict[str, Callable[[Any, Any, Mapping[str, Any], Mapping[str, Any]], float | None]] = {}
+
+
+def _safe(val: Any) -> float | None:
+    try:
+        f = float(val)
+    except Exception:
+        return None
+    if math.isnan(f) or math.isinf(f):
+        return None
+    return f
+
+
+def register(name: str):
+    def _wrap(fn: Callable[[Any, Any, Mapping[str, Any], Mapping[str, Any]], float | None]):
+        REGISTRY[name] = fn
+        return fn
+    return _wrap
+
+
+@register("base_pnl")
+def base_pnl(obs, action, info, state) -> float | None:
+    return _safe(info.get("pnl"))
+
+
+@register("risk_drawdown")
+def risk_drawdown(obs, action, info, state) -> float | None:
+    return _safe(info.get("drawdown"))
+
+
+@register("inventory_penalty")
+def inventory_penalty(obs, action, info, state) -> float | None:
+    return _safe(state.get("inventory"))
+
+
+@register("latency_penalty")
+def latency_penalty(obs, action, info, state) -> float | None:
+    return _safe(info.get("latency"))
+
+
+@register("slippage_penalty")
+def slippage_penalty(obs, action, info, state) -> float | None:
+    return _safe(info.get("slippage"))
+
+
+# ---------------------------------------------------------------------------
+# Spec loading and reward computation
+# ---------------------------------------------------------------------------
+
+
+def load_reward_spec(src: str | Path | Mapping[str, Any] | None) -> Dict[str, Any]:
+    if src is None:
+        data: Dict[str, Any] = {}
+    elif isinstance(src, (str, Path)):
+        with Path(src).open("r", encoding="utf-8") as fh:
+            data = yaml.safe_load(fh) or {}
+    else:
+        data = dict(src)
+    weights = {k: float(v) for k, v in (data.get("weights") or {}).items()}
+    clamp_data = data.get("clamps") or {}
+    clamps: Dict[str, Dict[str, float]] = {}
+    for k, v in clamp_data.items():
+        clamps[k] = {
+            "min": float(v.get("min", float("-inf"))),
+            "max": float(v.get("max", float("inf"))),
+        }
+    gc = data.get("global_clamp") or {}
+    global_clamp = {
+        "min": float(gc.get("min", float("-inf"))),
+        "max": float(gc.get("max", float("inf"))),
+    }
+    return {"weights": weights, "clamps": clamps, "global_clamp": global_clamp}
+
+
+def evaluate_terms(obs, action, info: Mapping[str, Any], state: Mapping[str, Any]) -> Dict[str, float]:
+    out: Dict[str, float] = {}
+    for name, fn in REGISTRY.items():
+        try:
+            val = fn(obs, action, info, state)
+        except Exception:
+            val = None
+        val = _safe(val)
+        if val is not None:
+            out[name] = float(val)
+    return out
+
+
+def compute_reward(
+    terms: Mapping[str, float],
+    weights: Mapping[str, float],
+    clamps: Mapping[str, Mapping[str, float]],
+    global_clamp: Mapping[str, float],
+) -> float:
+    total = 0.0
+    for name, weight in weights.items():
+        val = _safe(terms.get(name, 0.0))
+        if val is None:
+            val = 0.0
+        if name in clamps:
+            lo = clamps[name].get("min", float("-inf"))
+            hi = clamps[name].get("max", float("inf"))
+            val = max(lo, min(val, hi))
+        total += weight * val
+    lo = global_clamp.get("min", float("-inf"))
+    hi = global_clamp.get("max", float("inf"))
+    total = max(lo, min(total, hi))
+    total = _safe(total) or 0.0
+    return float(total)

--- a/bot_trade/tools/dev_checks.py
+++ b/bot_trade/tools/dev_checks.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from typing import Tuple
 
+from PIL import Image
+
 from bot_trade.config.rl_paths import (
     DEFAULT_KB_FILE,
     DEFAULT_LOGS_DIR,
@@ -86,6 +88,21 @@ def main(argv: list[str] | None = None) -> int:
         else:
             if not (charts_dir / "risk_flags.png").exists():
                 reasons.append("risk_flags.png missing")
+            rg = charts_dir / "regimes.png"
+            if not rg.exists():
+                reasons.append("regimes.png missing")
+            else:
+                size = rg.stat().st_size
+                dpi = 0
+                try:
+                    with Image.open(rg) as im:
+                        info = im.info.get("dpi") or (0, 0)
+                        dpi = int(round(info[0] if isinstance(info, tuple) else info))
+                except Exception:
+                    dpi = 0
+                if size < 1024 or dpi < 120:
+                    print("[CHECKS] regimes_png_too_small")
+                    reasons.append("regimes.png too small")
             for p in pngs:
                 if p.stat().st_size < 1024:
                     reasons.append(f"small {p.name}")

--- a/bot_trade/tools/export_charts.py
+++ b/bot_trade/tools/export_charts.py
@@ -333,6 +333,9 @@ def main(argv: list[str] | None = None) -> int:  # pragma: no cover - CLI helper
         )
     )
     print(f"[CHARTS] dir={charts_dir.resolve()} images={images}")
+    rg = charts_dir / "regimes.png"
+    if rg.exists():
+        print(f"[ADAPT_CHARTS] regimes_png={rg.resolve()}")
     return 0 if images > 0 else 2
 
 

--- a/bot_trade/tools/kb_writer.py
+++ b/bot_trade/tools/kb_writer.py
@@ -36,6 +36,7 @@ KB_DEFAULTS = {
     "best": False,
     "last": False,
     "best_model_path": "",
+    "logs": {"regime_log_count": 0, "adaptive_log_count": 0},
     "eval": {
         "win_rate": None,
         "sharpe": None,
@@ -89,11 +90,12 @@ def kb_append(run_paths: Any, payload: dict, kb_file: Optional[str] = None) -> N
         algo_meta["policy_kwargs"] = _condense_policy_kwargs(algo_meta.get("policy_kwargs") or {})
     entry = {
         **KB_DEFAULTS,
-        **{k: v for k, v in payload.items() if k not in {"eval", "portfolio", "algo_meta"}},
+        **{k: v for k, v in payload.items() if k not in {"eval", "portfolio", "algo_meta", "logs"}},
         "algo_meta": algo_meta,
     }
     entry["eval"] = {**KB_DEFAULTS["eval"], **payload.get("eval", {})}
     entry["portfolio"] = {**KB_DEFAULTS["portfolio"], **payload.get("portfolio", {})}
+    entry["logs"] = {**KB_DEFAULTS["logs"], **payload.get("logs", {})}
 
     # prevent duplicate run_id appends
     if path.exists():

--- a/bot_trade/train_rl.py
+++ b/bot_trade/train_rl.py
@@ -46,6 +46,8 @@ from bot_trade.tools._headless import ensure_headless_once
 
 
 from bot_trade.strat.adaptive_controller import AdaptiveController
+from bot_trade.strat.rewards_registry import load_reward_spec
+import yaml
 
 # Heavy dependencies (torch, numpy, pandas, stable_baselines3, etc.) are
 # imported inside `main` to keep import-time side effects minimal and to
@@ -80,6 +82,14 @@ def _write_regime_chart(charts_dir, dist):
         ax.set_axis_off()
     write_png(Path(charts_dir) / "regimes.png", fig, dpi=120)
     plt.close(fig)
+
+
+def _count_lines(p: Path) -> int:
+    try:
+        with Path(p).open("r", encoding="utf-8") as fh:
+            return sum(1 for _ in fh)
+    except Exception:
+        return 0
 
 def _postrun_summary(paths, meta):
     logger = logging.getLogger()
@@ -142,6 +152,10 @@ def _postrun_summary(paths, meta):
     rows_safety = row_counts.get("safety", 0)
     rows_callbacks = row_counts.get("callbacks", 0)
     rows_signals = row_counts.get("signals", 0)
+    meta["logs"] = {
+        "regime_log_count": _count_lines(rp.performance_dir / "regime_log.jsonl"),
+        "adaptive_log_count": _count_lines(rp.performance_dir / "adaptive_log.jsonl"),
+    }
     print(
         "[DEBUG_EXPORT] reward_rows=%d step_rows=%d train_rows=%d risk_rows=%d callbacks_rows=%d signals_rows=%d"
         % (
@@ -154,6 +168,9 @@ def _postrun_summary(paths, meta):
         )
     )
     print(f"[CHARTS] dir={charts_dir.resolve()} images={img_count}")
+    rg = charts_dir / "regimes.png"
+    if rg.exists():
+        print(f"[ADAPT_CHARTS] regimes_png={rg.resolve()}")
     if rows_risk == 0 and rows_safety == 0:
         print("[RISK_DIAG] no_flags_fired (smoke run)")
 
@@ -227,6 +244,7 @@ def _postrun_summary(paths, meta):
             "eval": eval_entry,
             "portfolio": portfolio_entry,
             "regime": meta.get("regime"),
+            "logs": meta.get("logs", {}),
             "safety": meta.get("safety"),
             "notes": str(meta.get("notes", "")),
         }
@@ -405,6 +423,26 @@ def train_one_file(args, data_file: str) -> bool:
         run_id = getattr(args, "run_id", None) or new_run_id(args.symbol, args.frame)
     args.run_id = run_id
     cfg = get_config()
+    reward_spec_path = getattr(args, "reward_spec", None)
+    if reward_spec_path is None:
+        default_rspec = Path("config/rewards/default.yml")
+        if default_rspec.exists():
+            reward_spec_path = default_rspec
+    reward_spec = load_reward_spec(reward_spec_path) if reward_spec_path else {"weights": {}, "clamps": {}, "global_clamp": {}}
+    rw_weights = reward_spec.get("weights", {})
+    if rw_weights:
+        rw_cfg = cfg.setdefault("reward_shaping", {})
+        rw_cfg["w_pnl"] = abs(float(rw_weights.get("base_pnl", rw_cfg.get("w_pnl", 1.0))))
+        rw_cfg["w_drawdown"] = abs(float(rw_weights.get("risk_drawdown", rw_cfg.get("w_drawdown", 0.5))))
+        rw_cfg["w_trade_cost"] = abs(float(rw_weights.get("slippage_penalty", rw_cfg.get("w_trade_cost", 0.1))))
+        rw_cfg["w_dwell"] = abs(float(rw_weights.get("inventory_penalty", rw_cfg.get("w_dwell", 0.01))))
+    adaptive_cfg: Dict[str, Any] = {}
+    if getattr(args, "adaptive_spec", None):
+        try:
+            with open(args.adaptive_spec, "r", encoding="utf-8") as fh:
+                adaptive_cfg = yaml.safe_load(fh) or {}
+        except Exception:
+            adaptive_cfg = {}
     sf_cfg = cfg.setdefault("strategy_failure", {})
     thr_cfg = sf_cfg.setdefault("thresholds", {})
     if getattr(args, "loss_streak", None) is not None:
@@ -626,9 +664,11 @@ def train_one_file(args, data_file: str) -> bool:
         base_env = vec_env.envs[0]
     except Exception:
         pass
-    if getattr(args, "regime_aware", False):
-        log_path = paths_obj.performance_dir / "adaptive_log.jsonl" if getattr(args, "regime_log", False) else None
-        controller = AdaptiveController(cfg.get("regime", {}), env=base_env, log_path=log_path)
+    if adaptive_cfg or getattr(args, "regime_aware", False):
+        regime_log = paths_obj.performance_dir / "regime_log.jsonl" if (getattr(args, "regime_log", False) or adaptive_cfg) else None
+        log_path = paths_obj.performance_dir / "adaptive_log.jsonl" if (getattr(args, "regime_log", False) or adaptive_cfg) else None
+        cfg_reg = adaptive_cfg if adaptive_cfg else cfg.get("regime", {})
+        controller = AdaptiveController(cfg_reg, env=base_env, log_path=log_path, regime_log_path=regime_log)
 
     risk_manager = None
     try:

--- a/config/rewards/default.yml
+++ b/config/rewards/default.yml
@@ -1,0 +1,9 @@
+weights:
+  base_pnl: 1.0
+  risk_drawdown: -0.5
+  slippage_penalty: -0.2
+clamps:
+  base_pnl: {min: -5.0, max: 5.0}
+  risk_drawdown: {min: -5.0, max: 5.0}
+  slippage_penalty: {min: -5.0, max: 5.0}
+global_clamp: {min: -10.0, max: 10.0}

--- a/config/strat/adaptive.yml
+++ b/config/strat/adaptive.yml
@@ -1,0 +1,12 @@
+detector:
+  seed: 0
+regime_rules:
+  vol_high:
+    reward_delta: { base_pnl: 0.1, risk_drawdown: -0.2 }
+    risk_clamp_delta: { max_position: -0.2, max_leverage: -0.5 }
+  trend_up:
+    reward_delta: { base_pnl: 0.2 }
+    risk_clamp_delta: { trailing_dd_limit: 0.1 }
+clamps:
+  reward_weight_delta: {min: -0.5, max: 0.5}
+  risk_bound_delta: {min: -1.0, max: 1.0}


### PR DESCRIPTION
## Summary
- debounce adaptive regime prints and seed regime detector for reproducible windows
- clamp non-finite reward terms to zero and nest log counts in KB entries
- verify regime chart DPI/size via dev_checks and add detector seed to adaptive config

## Testing
- `python -m py_compile $(git ls-files 'bot_trade/**/*.py' 'bot_trade/*.py')`
- `python -m bot_trade.tools.gen_synth_data --symbol BTCUSDT --frame 1m --out data_ready`
- `python -m bot_trade.train_rl --algorithm PPO --symbol BTCUSDT --frame 1m --device cpu --n-envs 1 --n-steps 64 --batch-size 64 --total-steps 128 --headless --allow-synth --data-dir data_ready --no-monitor`
- `python -m bot_trade.train_rl --algorithm SAC --continuous-env --symbol BTCUSDT --frame 1m --device cpu --n-envs 1 --n-steps 64 --batch-size 64 --total-steps 256 --headless --allow-synth --data-dir data_ready --no-monitor --reward-spec config/rewards/default.yml --adaptive-spec config/strat/adaptive.yml`
- `python -m bot_trade.tools.export_charts --symbol BTCUSDT --frame 1m --run-id latest --debug-export`
- `python -m bot_trade.tools.monitor_manager --symbol BTCUSDT --frame 1m --run-id latest --debug-export`
- `python -m bot_trade.tools.eval_run --symbol BTCUSDT --frame 1m --run-id latest --tearsheet`
- `python -m bot_trade.eval.tearsheet --symbol BTCUSDT --frame 1m --run-id latest`


------
https://chatgpt.com/codex/tasks/task_b_68b795211610832db9ee120aaf44e56c