### PR TITLE
Add CPU sweeper, checks, and smoke CI

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -5,28 +5,28 @@ on:
   pull_request:
 
 jobs:
-  linux-cpu:
+  smoke:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'
-      - run: pip install -r requirements.txt
-      - run: python -m py_compile $(git ls-files 'bot_trade/config/*.py' 'bot_trade/tools/*.py' 'bot_trade/eval/*.py' 'bot_trade/strat/*.py' 'bot_trade/env/*.py' 'bot_trade/train_rl.py')
+      - run: pip install -e .
+      - run: python -m py_compile $(git ls-files 'bot_trade/**/*.py' 'bot_trade/*.py')
       - run: python -m bot_trade.tools.gen_synth_data --symbol BTCUSDT --frame 1m --out data_ready
       - run: python -m bot_trade.train_rl --algorithm PPO --symbol BTCUSDT --frame 1m --device cpu --n-envs 1 --n-steps 32 --batch-size 32 --total-steps 64 --headless --allow-synth --data-dir data_ready
-      - run: python -m bot_trade.tools.eval_run --symbol BTCUSDT --frame 1m --run-id latest --algorithm PPO
+      - run: python -m bot_trade.tools.eval_run --symbol BTCUSDT --frame 1m --run-id latest
       - run: python -m bot_trade.train_rl --algorithm SAC --continuous-env --symbol BTCUSDT --frame 1m --device cpu --n-envs 1 --n-steps 32 --batch-size 32 --total-steps 64 --headless --allow-synth --data-dir data_ready
-      - run: python -m bot_trade.tools.eval_run --symbol BTCUSDT --frame 1m --run-id latest --algorithm SAC
+      - run: python -m bot_trade.tools.eval_run --symbol BTCUSDT --frame 1m --run-id latest
       - run: python -m bot_trade.tools.sweep --mode random --n-trials 4 --symbol BTCUSDT --frame 1m --algorithm SAC --continuous-env --headless --allow-synth --data-dir data_ready
       - run: python -m bot_trade.tools.dev_checks --symbol BTCUSDT --frame 1m --run-id latest
       - uses: actions/upload-artifact@v4
         with:
-          name: artifacts
+          name: reports
           path: |
             reports/**/charts/*.png
-            reports/**/performance/*
+            reports/**/tearsheet.html
             reports/**/sweep_*/summary.csv
             reports/**/sweep_*/summary.md
             reports/**/sweep_*/runs.jsonl

--- a/CHANGE_NOTES.md
+++ b/CHANGE_NOTES.md
@@ -406,3 +406,10 @@ Risks/Migration: callers importing from old locations must switch to canonical m
 - **Rationale**: add CPU-only sweep with grid/random modes and eval metrics, strengthen dev checks with chart DPI/size and ai_core signal assertions, log trailing newline fixes, and expand smoke CI to train/eval PPO+SAC and run random sweeps.
 - **Risks**: sweep may prolong CI; dev checks depend on knowledge base availability.
 - **Test Steps**: `python -m py_compile $(git ls-files 'bot_trade/**/*.py' 'bot_trade/*.py')`; `python -m bot_trade.tools.sweep --mode random --n-trials 4 --symbol BTCUSDT --frame 1m --algorithm SAC --continuous-env --headless --allow-synth --data-dir data_ready`; `python -m bot_trade.tools.dev_checks --symbol BTCUSDT --frame 1m --run-id latest`
+
+## Developer Notes — 2025-09-03 03:20:01 UTC
+- Added CPU sweeper (grid/random), atomic summaries (csv/md/jsonl), and [SWEEP] line
+- Implemented warning thresholds with env overrides; added [SWEEP_WARN] markers
+- Strengthened dev_checks (fields, charts DPI/size, ai_core signals) with summary [CHECKS]
+- Improved atomic writers with [IO] fixed_trailing_newline
+- Added smoke CI pipeline and artifacts

--- a/DEV_NOTES.md
+++ b/DEV_NOTES.md
@@ -225,3 +225,10 @@ that direct execution (`python tools/export_charts.py`) still works if needed.
 - Risks: sweep runs still spawn training loops; dev_checks rely on KB entries.
 - Migration Steps: use `python -m bot_trade.tools.sweep` and `python -m bot_trade.tools.dev_checks --symbol <S> --frame <F> --run-id latest`.
 - Next Actions: broaden hyper-parameter coverage and extend checks to additional artifacts.
+
+## Developer Notes — 2025-09-03 03:20:01 UTC
+- What: finalized CPU sweeper with warning thresholds and artifact checks, hardened dev_checks for fields/charts/signals, added smoke CI pipeline, and ensured newline fixes log via `[IO]`.
+- Why: provide reproducible hyperparameter sweeps and stronger validation in development and CI.
+- Risks: sweeps may be slow; dev_checks require populated knowledge base entries.
+- Migration Steps: invoke `tools.sweep` for CPU grids or random trials; run `tools.dev_checks --run-id latest` after sweeps; review smoke workflow for expected commands.
+- Next Actions: expand sweep hyper-parameters and extend dev checks to additional artifacts and metrics.

--- a/bot_trade/tools/dev_checks.py
+++ b/bot_trade/tools/dev_checks.py
@@ -49,12 +49,13 @@ def main(argv: List[str] | None = None) -> int:
     algo = (kb_entry.get("algorithm") or "").upper()
     warnings = 0
 
+    missing: list[str] = []
     if not algo:
-        print("[CHECKS] missing_algorithm")
-        warnings += 1
-
+        missing.append("algorithm")
     if kb_entry.get("eval", {}).get("max_drawdown") is None:
-        print("[CHECKS] missing_eval_max_drawdown")
+        missing.append("eval.max_drawdown")
+    if missing:
+        print(f"[CHECKS] missing_fields fields={','.join(missing)}")
         warnings += 1
 
     rp = RunPaths(args.symbol, args.frame, run_id, algo or "PPO")
@@ -89,8 +90,6 @@ def main(argv: List[str] | None = None) -> int:
                 with sig.open("ab") as fh:
                     fh.write(b"\n")
                 print(f"[IO] fixed_trailing_newline file={sig}")
-                print("[CHECKS] signals_jsonl_fixed_newline")
-                warnings += 1
         except FileNotFoundError:
             print("[CHECKS] signals_jsonl_missing")
             warnings += 1


### PR DESCRIPTION
## Summary
- add CPU sweeper supporting grid/random modes, env threshold warnings, and atomic summaries
- strengthen dev checks for required fields, chart integrity, and signal newline fixes
- wire smoke CI running synth data, PPO/SAC training, sweeps, and artifact collection

## Testing
- `python -m py_compile $(git ls-files 'bot_trade/**/*.py' 'bot_trade/*.py')`
- `python -m bot_trade.tools.gen_synth_data --symbol BTCUSDT --frame 1m --out data_ready`
- `python -m bot_trade.tools.sweep --mode random --n-trials 4 --symbol BTCUSDT --frame 1m --algorithm SAC --continuous-env --headless --allow-synth --data-dir data_ready`
- `python -m bot_trade.tools.dev_checks --symbol BTCUSDT --frame 1m --run-id latest`

------
https://chatgpt.com/codex/tasks/task_b_68b7b305b4ac832d9d67c1f9332f36a4