### PR TITLE
chore: release docs and version wrappers

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -22,6 +22,8 @@ jobs:
       - run: python -m bot_trade.tools.sweep --mode random --n-trials 4 --symbol BTCUSDT --frame 1m --algorithm SAC --continuous-env --headless --allow-synth --data-dir data_ready
       - run: python -m bot_trade.tools.train_long_run --algorithm SAC --continuous-env --symbol BTCUSDT --frame 1m --headless --allow-synth --data-dir data_ready --preset training=sac_cont_cpu_smoke --preset net=tiny --save-every 32 --eval-every 32 --max-steps 32
       - run: python -m bot_trade.tools.dev_checks --symbol BTCUSDT --frame 1m --run-id latest
+      - run: python -m bot_trade.tools.mk_artifacts_index --symbol BTCUSDT --frame 1m --run-id latest --algorithm SAC || true
+      - run: python -m bot_trade.tools.print_version
       - uses: actions/upload-artifact@v4
         with:
           name: reports
@@ -35,3 +37,4 @@ jobs:
             reports/**/summary.md
             reports/**/runs.jsonl
             reports/**/checkpoints/index.csv
+            reports/**/artifacts/index.json

--- a/CHANGE_NOTES.md
+++ b/CHANGE_NOTES.md
@@ -419,3 +419,17 @@ Risks/Migration: callers importing from old locations must switch to canonical m
 - Implemented tools/train_long_run.py with periodic eval/tearsheet & checkpoints
 - Added optional risk config flags with clamps and [RISK_CFG]/[RISK_CLAMP] one-liners
 - Preserved sweeper thresholds & warns; no behavior changes to existing CLIs
+
+## Developer Notes — 2025-09-03 04:08:10 UTC
+- What changed: release prep docs (RELEASE, QUICKSTART), Makefile wrappers, version module and printer, artifacts index helper, Dockerfile.smoke, CI version step
+- Why: streamline release packaging and provide quickstart guidance
+- Risks: artifacts index path assumptions; wrappers depend on existing CLIs
+- Migration steps: none; new tools optional
+- Next actions: tag v0.1.0 and extend automation
+
+## Developer Notes — 2025-09-03 04:16:54 UTC
+- What changed: artifacts index now mirrors to legacy report path
+- Why: ensure discovery via simple glob
+- Risks: duplicate writes are minimal
+- Migration steps: none
+- Next actions: monitor index usage

--- a/Dockerfile.smoke
+++ b/Dockerfile.smoke
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY . /app
+RUN pip install --no-cache-dir -r requirements.txt || true
+# Optional extras guarded internally
+# CMD is intentionally empty; CI sets commands

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: train evaluate evaluate-full rl-train rl-run run dashboard install
+.PHONY: train evaluate evaluate-full rl-train rl-run run dashboard install smoke sweep longrun docs clean
 
 install:
 	pip install -r requirements.txt
@@ -32,8 +32,32 @@ docker-build:
 	docker build -t $(IMAGE_NAME) .
 
 docker-run:
-        docker run --rm -it $(IMAGE_NAME)
+	docker run --rm -it $(IMAGE_NAME)
 
 devmap:
-        python -m tools.generate_dev_map > docs/bot_map.md
+	python -m tools.generate_dev_map > docs/bot_map.md
 
+
+smoke:
+	python -m py_compile $$(git ls-files 'bot_trade/**/*.py' 'bot_trade/*.py'); \
+	python -m bot_trade.tools.gen_synth_data --symbol BTCUSDT --frame 1m --out data_ready; \
+	python -m bot_trade.train_rl --algorithm PPO --symbol BTCUSDT --frame 1m --device cpu --n-envs 1 --total-steps 128 --headless --allow-synth --data-dir data_ready --no-monitor; \
+	python -m bot_trade.tools.eval_run --symbol BTCUSDT --frame 1m --run-id latest --tearsheet; \
+	python -m bot_trade.tools.mk_artifacts_index --symbol BTCUSDT --frame 1m --run-id latest --algorithm PPO
+
+sweep:
+	python -m bot_trade.tools.sweep --mode random --n-trials 4 \
+	  --symbol BTCUSDT --frame 1m --algorithm SAC --continuous-env \
+	  --headless --allow-synth --data-dir data_ready
+
+longrun:
+	python -m bot_trade.tools.train_long_run --algorithm SAC --continuous-env \
+	  --symbol BTCUSDT --frame 1m --headless --allow-synth --data-dir data_ready \
+	  --preset training=sac_cont_cpu_smoke --preset net=tiny \
+	  --save-every 128 --eval-every 128 --max-steps 256
+
+docs:
+	@ls docs/REGISTRIES.md docs/CLI_HELP.md docs/KB_SCHEMA.md docs/RELEASE.md docs/QUICKSTART.md
+
+clean:
+	find reports -name '*.tmp' -delete || true

--- a/bot_trade/__version__.py
+++ b/bot_trade/__version__.py
@@ -1,0 +1,2 @@
+__version__ = "0.1.0"
+__build_meta__ = {"schema_kb": "v1", "registry": ["algos","rewards","risk","slippage","features"]}

--- a/bot_trade/tools/mk_artifacts_index.py
+++ b/bot_trade/tools/mk_artifacts_index.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+
+from .atomic_io import write_json
+from .latest import latest_run
+from .paths import report_dir
+
+
+def main(argv: list[str] | None = None) -> None:
+    ap = argparse.ArgumentParser("mk_artifacts_index")
+    ap.add_argument("--symbol", required=True)
+    ap.add_argument("--frame", required=True)
+    ap.add_argument("--run-id", default="latest")
+    ap.add_argument("--algorithm")
+    ns = ap.parse_args(argv)
+
+    algo = ns.algorithm
+    run_id = ns.run_id
+    base = report_dir(ns.symbol, ns.frame, algo=algo)
+    if run_id == "latest":
+        rid = latest_run(ns.symbol, ns.frame, base.parent.parent)
+        if not rid:
+            print("[LATEST] none")
+            return
+        run_id = rid
+    run_dir = base / run_id
+
+    charts_dir = run_dir / "charts"
+    charts = sorted(p.name for p in charts_dir.glob("*.png"))
+
+    data = {
+        "run_id": run_id,
+        "algorithm": algo or "",
+        "symbol": ns.symbol,
+        "frame": ns.frame,
+        "charts": charts,
+        "tearsheet": "tearsheet.html",
+        "kb_line_path": "memory/Knowlogy/kb.jsonl",
+        "created_utc": dt.datetime.utcnow().isoformat(),
+    }
+    out_path = run_dir / "artifacts" / "index.json"
+    write_json(out_path, data)
+    if algo:
+        legacy = report_dir(ns.symbol, ns.frame) / run_id / "artifacts" / "index.json"
+        write_json(legacy, data)
+    print(f"[ARTIFACTS] index={out_path.resolve()} charts={len(charts)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/bot_trade/tools/print_version.py
+++ b/bot_trade/tools/print_version.py
@@ -1,0 +1,9 @@
+from bot_trade.__version__ import __version__, __build_meta__
+
+
+def main() -> None:
+    print(f"[VERSION] {__version__} build={__build_meta__}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,0 +1,19 @@
+# Quickstart
+
+1. Synthetic data + PPO eval
+```bash
+python -m bot_trade.tools.gen_synth_data --symbol BTCUSDT --frame 1m --out data_ready
+python -m bot_trade.train_rl --algorithm PPO --symbol BTCUSDT --frame 1m --device cpu --n-envs 1 --total-steps 128 --headless --allow-synth --data-dir data_ready --no-monitor
+python -m bot_trade.tools.eval_run --symbol BTCUSDT --frame 1m --run-id latest --tearsheet
+```
+
+2. Continuous SAC
+```bash
+python -m bot_trade.train_rl --algorithm SAC --continuous-env --symbol BTCUSDT --frame 1m --device cpu --n-envs 1 --total-steps 128 --headless --allow-synth --data-dir data_ready --no-monitor
+python -m bot_trade.tools.eval_run --symbol BTCUSDT --frame 1m --run-id latest
+```
+
+3. ai_core dummy signals
+```bash
+python -m bot_trade.train_rl --algorithm SAC --continuous-env --symbol BTCUSDT --frame 1m --device cpu --n-envs 1 --total-steps 128 --headless --allow-synth --data-dir data_ready --ai-core --emit-dummy-signals --no-monitor
+```

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,33 @@
+# Release Checklist
+
+## Pre-release
+- `python -m py_compile $(git ls-files 'bot_trade/**/*.py' 'bot_trade/*.py')`
+- Run CPU smokes for PPO and SAC; logs contain `[EVAL]` and `[POSTRUN]`.
+- `python -m bot_trade.tools.dev_checks --symbol BTCUSDT --frame 1m --run-id latest` → `[CHECKS] ok=.. warnings=..`
+- `python -m bot_trade.tools.sweep --mode random --n-trials 4 --symbol BTCUSDT --frame 1m --algorithm SAC --continuous-env --headless --allow-synth --data-dir data_ready` → `[SWEEP]` with CSV/MD/JSONL.
+- Ensure tearsheet generated for latest run.
+
+## Artifacts
+- `reports/.../charts/*.png`
+- `reports/.../tearsheet.html`
+- `reports/.../sweep/summary.csv|summary.md|runs.jsonl`
+- optional `checkpoints/` index
+
+## Guards
+- `[ALGO_GUARD]`
+- `[SWEEP_WARN]`
+- `[RISK_CLAMP]`
+- `[IO] fixed_trailing_newline`
+
+## Reproduce
+```bash
+python -m bot_trade.tools.gen_synth_data --symbol BTCUSDT --frame 1m --out data_ready
+python -m bot_trade.train_rl --algorithm PPO --symbol BTCUSDT --frame 1m --device cpu --n-envs 1 --total-steps 128 --headless --allow-synth --data-dir data_ready --no-monitor
+python -m bot_trade.tools.eval_run --symbol BTCUSDT --frame 1m --run-id latest --tearsheet
+python -m bot_trade.tools.sweep --mode random --n-trials 4 --symbol BTCUSDT --frame 1m --algorithm SAC --continuous-env --headless --allow-synth --data-dir data_ready
+python -m bot_trade.tools.dev_checks --symbol BTCUSDT --frame 1m --run-id latest
+```
+
+## Versioning
+- Tag as `v<major>.<minor>.<patch>`.
+- Update `bot_trade/__version__.py` and `CHANGE_NOTES.md`.


### PR DESCRIPTION
## Summary
- add RELEASE and QUICKSTART guides
- expose project version and helper to print it
- convenience make targets and artifacts indexing

## Testing
- `python -m py_compile $(git ls-files 'bot_trade/**/*.py' 'bot_trade/*.py')`
- `make smoke`
- `make sweep`
- `python -m bot_trade.tools.print_version`
- `ls reports/*/*/*/artifacts/index.json`
- `test -f docs/RELEASE.md && echo OK_RELEASE_DOC`


------
https://chatgpt.com/codex/tasks/task_b_68b7be1c933c832dba2f3424a0239655