### PR TITLE
docs: add vecnorm migration guide

### DIFF
--- a/CHANGE_NOTES.md
+++ b/CHANGE_NOTES.md
@@ -448,3 +448,9 @@ Risks/Migration: callers importing from old locations must switch to canonical m
 - **Rationale**: harden path and encoding contracts, restore default config flow, centralize action-space detection, and lay groundwork for data platform.
 - **Risks**: deprecated vecnorm_path may mask legacy layouts; action-space API change may break external extensions; data store remains stub.
 - **Test Steps**: `python -m py_compile $(git ls-files 'bot_trade/**/*.py' 'bot_trade/*.py')`; `python -m bot_trade.tools.make_config --out config_new.yaml --preset training=sac_cont_cpu_smoke --preset net=tiny`; `python -m bot_trade.tools.gen_synth_data --symbol BTCUSDT --frame 1m --out data_ready`; `python -m bot_trade.train_rl --algorithm PPO --symbol BTCUSDT --frame 1m --total-steps 128 --headless --allow-synth --data-dir data_ready --no-monitor`; `python -m bot_trade.train_rl --algorithm SAC --continuous-env --symbol BTCUSDT --frame 1m --total-steps 128 --headless --allow-synth --data-dir data_ready --no-monitor --policy-kwargs '{"net_arch":[256,256],"activation_fn":"ReLU"}'`; `python -m bot_trade.tools.paths_doctor --symbol BTCUSDT --frame 1m --run-id latest`; `python -m bot_trade.tools.data_doctor`; `python -m bot_trade.tools.dev_checks --symbol BTCUSDT --frame 1m --run-id latest`
+
+## 2025-09-03
+- **Files**: MIGRATION.md, DEV_NOTES.md, CHANGE_NOTES.md
+- **Rationale**: add migration guide covering vecnorm path change and configuration precedence; record developer notes.
+- **Risks**: documentation may become outdated if paths or config flow change again.
+- **Test Steps**: `python -m py_compile $(git ls-files 'bot_trade/**/*.py' 'bot_trade/*.py')`; smoke training and tests below.

--- a/DEV_NOTES.md
+++ b/DEV_NOTES.md
@@ -239,3 +239,10 @@ that direct execution (`python tools/export_charts.py`) still works if needed.
 - Risks: deprecated vecnorm_path may hide legacy layouts; minimal data store offers limited validation.
 - Migration steps: use `RunPaths.features.vecnorm` for new paths, regenerate configs via `tools.make_config`, run `paths_doctor`/`data_doctor` for diagnostics.
 - Next actions: flesh out data store backends and expand config schema.
+
+## Developer Notes — 2025-09-03T06:09:32Z
+- Documented vecnorm path migration and configuration precedence in new `MIGRATION.md`.
+- Rationale: clarify algorithm/run-scoped vecnorm files and config source order for users.
+- Risks: outdated scripts may still rely on old paths; ensure deprecation notice is monitored.
+- Migration steps: adopt `RunPaths.features.vecnorm` and regenerate configs as needed.
+- Next actions: expand migration guide with future breaking changes.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,26 @@
+# Migration Guide
+
+This project evolves over time; key changes impacting usage are documented here.
+
+## VecNormalize paths
+
+VecNormalize files are now scoped by algorithm and run ID via `RunPaths.features.vecnorm`. Legacy locations are read once and redirect to the new path, printing a single `[DEPRECATION] vecnorm legacy path used → redirected` line.
+
+### Action
+
+- Tools and scripts should stop using `vecnorm_path(...)` and rely on `RunPaths.features.vecnorm`.
+- After migration, remove legacy vecnorm files.
+
+## Configuration source order
+
+Configuration settings are loaded with the following precedence:
+
+1. CLI arguments
+2. `config.yaml` (if present)
+3. `config.default.yaml`
+
+### Action
+
+- Place project defaults in `config.default.yaml`.
+- Create `config.yaml` for local overrides or generate one via `python -m bot_trade.tools.make_config`.
+


### PR DESCRIPTION
## Summary
- document algorithm/run-scoped VecNormalize paths and config precedence in MIGRATION.md
- log migration notes in DEV_NOTES and CHANGE_NOTES

## Testing
- `python -m py_compile $(git ls-files 'bot_trade/**/*.py' 'bot_trade/*.py')`
- `python -m bot_trade.tools.make_config --out config.yaml --preset training=sac_cont_cpu_smoke --preset net=tiny`
- `python -m bot_trade.tools.gen_synth_data --symbol BTCUSDT --frame 1m --out data_ready`
- `python -m bot_trade.train_rl --algorithm PPO --symbol BTCUSDT --frame 1m --device cpu --n-envs 1 --total-steps 128 --headless --allow-synth --data-dir data_ready --no-monitor --vecnorm`
- `python -m bot_trade.train_rl --algorithm SAC --continuous-env --symbol BTCUSDT --frame 1m --device cpu --n-envs 1 --total-steps 128 --headless --allow-synth --data-dir data_ready --no-monitor --policy-kwargs '{"net_arch":[256,256],"activation_fn":"ReLU"}' --vecnorm`
- `python -m bot_trade.tools.paths_doctor --symbol BTCUSDT --frame 1m --run-id latest --algorithm SAC`
- `python -m bot_trade.tools.data_doctor`
- `python -m bot_trade.tools.dev_checks --symbol BTCUSDT --frame 1m --run-id latest`
- `PYTHONPATH=. pytest -q tests/smoke/test_utf8.py tests/smoke/test_action_detect.py tests/unit/test_splits.py tests/smoke/test_vecnorm_paths.py`


------
https://chatgpt.com/codex/tasks/task_b_68b7db4fbeb0832dbf636696e2a7f823