### PR TITLE
Consolidate action space and enforce UTF-8

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,8 @@
+target-version = "py39"
+
+[lint]
+extend-select = ["E", "F", "I", "UP"]
+ignore = ["E501"]
+
+[lint.per-file-ignores]
+"__init__.py" = ["F401"]

--- a/CHANGE_NOTES.md
+++ b/CHANGE_NOTES.md
@@ -490,3 +490,9 @@ from bot_trade.tools.force_utf8 import force_utf8
 force_utf8()
 print("[CHECK]", os.environ.get("PYTHONIOENCODING"), getattr(sys.stdout, "encoding", None))
 PY`
+
+## 2025-10-11
+- **Files**: .ruff.toml, bot_trade/env/space_detect.py, bot_trade/env/action_space.py, bot_trade/config/rl_builders.py, bot_trade/runners/train_rl.py, bot_trade/train_rl.py, tests/smoke/test_action_detect.py, tests/smoke/test_utf8.py
+- **Rationale**: finalize typed action-space API with bounds, enforce single UTF-8 notice, add continuous-env validation, drop emoji logs, and introduce ruff lint gates.
+- **Risks**: strict env checks may abort misconfigured runs; legacy imports should migrate off the deprecated shim.
+- **Test Steps**: `python -m py_compile $(git ls-files 'bot_trade/**/*.py' 'bot_trade/*.py')`; `ruff check bot_trade --fix-only`; `mypy --strict bot_trade/env/space_detect.py bot_trade/env/action_space.py bot_trade/config/rl_builders.py bot_trade/tools/force_utf8.py`; `PYTHONPATH=. pytest -q -k 'smoke and (action_detect or utf8)'`; `python -m bot_trade.tools.gen_synth_data --symbol BTCUSDT --frame 1m --out data_ready`; `python -m bot_trade.runners.train_rl --algorithm PPO --symbol BTCUSDT --frame 1m --device cpu --n-envs 1 --total-steps 128 --headless --allow-synth --data-dir data_ready --no-monitor`; `python -m bot_trade.runners.train_rl --algorithm SAC --continuous-env --symbol BTCUSDT --frame 1m --device cpu --n-envs 1 --total-steps 128 --headless --allow-synth --data-dir data_ready --no-monitor`

--- a/DEV_NOTES.md
+++ b/DEV_NOTES.md
@@ -272,3 +272,11 @@ that direct execution (`python tools/export_charts.py`) still works if needed.
 - Risks: external consumers expecting dicts from `detect_action_space` must adapt; UTF-8 enforcement relies on `reconfigure` support.
 - Migration steps: import from `bot_trade.env.space_detect`, call `force_utf8()` in custom CLIs if not already; run `mypy` with new config.
 - Next actions: extend typing to additional modules and monitor deprecation notices for remaining shims.
+## Developer Notes — 2025-09-03T22:09:01Z (Action-space consolidation)
+- What changed: finalized `ActionSpaceInfo` with optional bounds, enforced `_require_box` and continuous-env checks in RL builders, added `.ruff.toml`, removed emoji training log, and ensured UTF-8 notices via `force_utf8()` in runners.
+- Why: complete action-space API and tighten lint/type gates.
+- Risks: misconfigured `--continuous-env` now aborts; shim prints once per process and asserts parity.
+- Migration steps: import from `bot_trade.env.space_detect`; legacy calls use `env.action_space` shim (single `[DEPRECATION]`).
+- Next actions: widen typing coverage and phase out deprecated shim.
+- py.typed location: `bot_trade/py.typed`.
+- Tests/lint/type: `python -m py_compile $(git ls-files 'bot_trade/**/*.py' 'bot_trade/*.py')`; `ruff check bot_trade --fix-only`; `mypy --strict bot_trade/env/space_detect.py bot_trade/env/action_space.py bot_trade/config/rl_builders.py bot_trade/tools/force_utf8.py`; `PYTHONPATH=. pytest -q -k 'smoke and (action_detect or utf8)'`; PPO/SAC smoke training commands above.

--- a/bot_trade/env/action_space.py
+++ b/bot_trade/env/action_space.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from .space_detect import ActionSpaceInfo, detect_action_space as _detect_action_space
+from .space_detect import ActionSpaceInfo
+from .space_detect import detect_action_space as _detect_action_space
 
 _WARNED = False
 
@@ -12,19 +13,27 @@ _WARNED = False
 def _warn_once() -> None:
     global _WARNED
     if not _WARNED:
-        print(
-            "[DEPRECATION] bot_trade.env.action_space is deprecated; use bot_trade.env.space_detect"
-        )
+        print("[DEPRECATION] bot_trade.env.action_space is deprecated; use bot_trade.env.space_detect")
         _WARNED = True
 
 
 _warn_once()
 
 
-def detect_action_space(space: Any) -> ActionSpaceInfo:
+class _Wrap:
+    def __init__(self, space: Any) -> None:
+        self.action_space = space
+
+
+def detect_action_space(env: Any) -> ActionSpaceInfo:
     """Legacy wrapper for :func:`bot_trade.env.space_detect.detect_action_space`."""
 
-    return _detect_action_space(space)
+    if hasattr(env, "action_space"):
+        info_env = _detect_action_space(env)
+        info_space = _detect_action_space(env.action_space)
+        assert info_env == info_space
+        return info_env
+    return _detect_action_space(_Wrap(env))
 
 
 __all__ = ["ActionSpaceInfo", "detect_action_space"]

--- a/bot_trade/runners/train_rl.py
+++ b/bot_trade/runners/train_rl.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+from bot_trade.tools.force_utf8 import force_utf8
 from bot_trade.train_rl import main
 
 if __name__ == "__main__":  # pragma: no cover
+    force_utf8()
     raise SystemExit(main())

--- a/tests/smoke/test_action_detect.py
+++ b/tests/smoke/test_action_detect.py
@@ -1,9 +1,28 @@
-from bot_trade.env.action_space import detect_action_space
 import gymnasium as gym
 
+from bot_trade.env.action_space import detect_action_space as legacy_detect
+from bot_trade.env.space_detect import detect_action_space
 
-def test_box_detection():
-    env = gym.make('Pendulum-v1')
+
+def test_box_detection_and_shim():
+    env = gym.make("Pendulum-v1")
     info = detect_action_space(env)
-    assert not info.is_discrete and info.shape[0] == env.action_space.shape[0]
+    legacy_env = legacy_detect(env)
+    legacy_space = legacy_detect(env.action_space)
+    assert info == legacy_env == legacy_space
+    assert not info.is_discrete
+    assert info.shape == env.action_space.shape
+    assert info.low == float(env.action_space.low.min())
+    assert info.high == float(env.action_space.high.max())
+    env.close()
 
+
+def test_discrete_detection():
+    env = gym.make("CartPole-v1")
+    info = detect_action_space(env)
+    assert info.is_discrete
+    assert info.shape == (1,)
+    assert info.low == 0.0
+    assert info.high == env.action_space.n - 1
+    assert legacy_detect(env) == info
+    env.close()

--- a/tests/smoke/test_utf8.py
+++ b/tests/smoke/test_utf8.py
@@ -1,10 +1,11 @@
-from bot_trade.tools.force_utf8 import force_utf8
 import os
 
+from bot_trade.tools.force_utf8 import force_utf8
 
-def test_force_utf8(capsys):
+
+def test_force_utf8_once(capsys):
+    force_utf8()
     force_utf8()
     assert os.environ.get("PYTHONIOENCODING") == "UTF-8"
-    out = capsys.readouterr().out.strip()
-    assert out == "[ENCODING] UTF-8"
-
+    out = capsys.readouterr().out.splitlines()
+    assert out == ["[ENCODING] UTF-8"]


### PR DESCRIPTION
## Summary
- finalize `ActionSpaceInfo` with optional bounds and pure `detect_action_space`
- add deprecation shim with parity assert and continuous-env validation guards
- enforce single UTF-8 notice and remove emoji training log; add Ruff config

## Testing
- `python -m py_compile $(git ls-files 'bot_trade/**/*.py' 'bot_trade/*.py')`
- `ruff check bot_trade/env/space_detect.py bot_trade/env/action_space.py bot_trade/config/rl_builders.py bot_trade/runners/train_rl.py bot_trade/train_rl.py tests/smoke/test_action_detect.py tests/smoke/test_utf8.py --fix-only`
- `mypy --strict bot_trade/env/space_detect.py bot_trade/env/action_space.py bot_trade/config/rl_builders.py bot_trade/tools/force_utf8.py`
- `PYTHONPATH=. pytest -q -k 'smoke and (action_detect or utf8)'`
- `python -m bot_trade.tools.gen_synth_data --symbol BTCUSDT --frame 1m --out data_ready`
- `python -m bot_trade.runners.train_rl --algorithm PPO --symbol BTCUSDT --frame 1m --device cpu --n-envs 1 --total-steps 128 --headless --allow-synth --data-dir data_ready --no-monitor`
- `python -m bot_trade.runners.train_rl --algorithm SAC --continuous-env --symbol BTCUSDT --frame 1m --device cpu --n-envs 1 --total-steps 128 --headless --allow-synth --data-dir data_ready --no-monitor`


------
https://chatgpt.com/codex/tasks/task_b_68b8b7aa8370832d9eb20c00eb5fd7a7