### PR TITLE
Add paper trading gateway stub and CLI

### DIFF
--- a/CHANGE_NOTES.md
+++ b/CHANGE_NOTES.md
@@ -507,3 +507,8 @@ PY`
 - **Rationale**: finalize execution simulator and risk artifacts with JSONL logging, registry-driven slippage, config flags, and KB/dev checks wiring.
 - **Risks**: consumers relying on `risk_log.csv` must migrate; risk rule integration remains superficial.
 - **Test Steps**: compile, synth data, PPO/SAC smoke, charts, eval_run, sweep, dev_checks.
+## 2025-09-03
+- **Files**: bot_trade/gateways/paper.py, bot_trade/gateways/__init__.py, bot_trade/config/rl_args.py, bot_trade/train_rl.py, docs/QUICKSTART.md, docs/RELEASE.md, DEV_NOTES.md
+- **Rationale**: add paper trading gateway stub with CLI flag and docs updates.
+- **Risks**: gateway lacks persistence and real fill handling; future integration may change interface.
+- **Test Steps**: py_compile; synth data; PPO smoke; SAC smoke with `--gateway paper`; export_charts; eval_run; sweep; dev_checks.

--- a/DEV_NOTES.md
+++ b/DEV_NOTES.md
@@ -292,3 +292,9 @@ that direct execution (`python tools/export_charts.py`) still works if needed.
 - Risks: legacy consumers expect risk_log.csv; risk rule registry is stubbed.
 - Migration steps: use --exec-config/--risk-config, read risk_flags.jsonl, update parsers for KB charts/execution/risk.
 - Next actions: wire risk rules into runtime and expand bridge integration.
+## Developer Notes — 2025-09-03T23:14:21Z (Paper gateway skeleton)
+- What changed: introduced in-memory `PaperGateway`, exposed via `--gateway` CLI flag, auto-initialised in `train_rl`, and updated quickstart/release docs.
+- Why: allow smoke tests to exercise a paper trading path and emit `[GATEWAY]` notices.
+- Risks: gateway is non-persistent and lacks real fills or reconciliation; future integration may alter interfaces.
+- Migration steps: pass `--gateway paper` (default) when training; import gateways from `bot_trade.gateways`.
+- Next actions: hook gateway into execution bridge, add fill polling, and expand risk wiring.

--- a/bot_trade/config/rl_args.py
+++ b/bot_trade/config/rl_args.py
@@ -154,6 +154,7 @@ def parse_args():
     )
     ap.add_argument("--exec-config", type=str, default=None, help="Execution YAML config")
     ap.add_argument("--risk-config", type=str, default=None, help="Risk YAML config")
+    ap.add_argument("--gateway", type=str, default="paper", help="Execution gateway (paper|sandbox|ccxt)")
     ap.add_argument("--policy", type=str, default="MlpPolicy")
     ap.add_argument("--device", type=str, default=None)
     ap.add_argument("--n-envs", type=int, default=0)

--- a/bot_trade/gateways/__init__.py
+++ b/bot_trade/gateways/__init__.py
@@ -1,1 +1,5 @@
-__all__: list[str] = []
+"""Gateway exports."""
+from .paper import PaperGateway
+from .ccxt_adapter import CCXTAdapter
+
+__all__ = ["PaperGateway", "CCXTAdapter"]

--- a/bot_trade/gateways/paper.py
+++ b/bot_trade/gateways/paper.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+"""In-memory paper trading gateway used for smoke tests.
+
+This gateway is intentionally lightweight: it implements the minimal
+order/position interface expected by the execution bridge while avoiding any
+external side effects.  All writes and fills are kept in memory and the
+interface is synchronous.
+"""
+from dataclasses import dataclass, field
+import time
+from typing import Any, Dict, List
+
+from bot_trade.tools.force_utf8 import force_utf8
+
+
+@dataclass
+class PaperGateway:
+    """Simple paper gateway with basic rate limiting and idempotency."""
+
+    symbol: str
+    rate_limit_per_sec: int = 5
+    _orders: Dict[str, Dict[str, Any]] = field(default_factory=dict, init=False)
+    _fills: List[Dict[str, Any]] = field(default_factory=list, init=False)
+    _last_refill: float = field(default_factory=time.time, init=False)
+    _tokens: int = field(init=False)
+
+    def __post_init__(self) -> None:
+        force_utf8()
+        self._tokens = self.rate_limit_per_sec
+        print("[GATEWAY] provider=paper")
+
+    # ------------------------------------------------------------------
+    def _refill(self) -> None:
+        now = time.time()
+        if now - self._last_refill >= 1.0:
+            self._tokens = self.rate_limit_per_sec
+            self._last_refill = now
+
+    def _consume(self) -> bool:
+        self._refill()
+        if self._tokens <= 0:
+            print("[GATEWAY] rate_limit exceeded")
+            return False
+        self._tokens -= 1
+        return True
+
+    def _deterministic_id(self, order: Dict[str, Any]) -> str:
+        base = f"{order.get('side')}:{order.get('qty')}:{order.get('price')}"
+        return str(abs(hash(base)) % (10 ** 12))
+
+    # ------------------------------------------------------------------
+    def submit(self, order: Dict[str, Any]) -> Dict[str, Any]:
+        """Accept an order returning an acknowledgement."""
+        self._consume()
+        oid = self._deterministic_id(order)
+        if oid in self._orders:
+            return {"id": oid, "status": "duplicate"}
+        self._orders[oid] = order.copy()
+        return {"id": oid, "status": "accepted"}
+
+    def poll_fills(self) -> List[Dict[str, Any]]:
+        fills = self._fills[:]
+        self._fills.clear()
+        return fills
+
+    def positions(self) -> Dict[str, float]:
+        return {}
+
+    def balances(self) -> Dict[str, float]:
+        return {}
+
+    def cancel(self, oid: str) -> bool:
+        return self._orders.pop(oid, None) is not None
+
+    def clock(self) -> float:
+        return time.time()
+
+
+__all__ = ["PaperGateway"]

--- a/bot_trade/train_rl.py
+++ b/bot_trade/train_rl.py
@@ -1362,6 +1362,17 @@ def main():
     _apply_presets(args)
     args.kb_file = str(Path(getattr(args, "kb_file", DEFAULT_KB_FILE) or DEFAULT_KB_FILE))
 
+    # Initialise gateway for side-effect logging (e.g. [GATEWAY] line)
+    gw = getattr(args, "gateway", "paper")
+    if gw == "paper":
+        from bot_trade.gateways import PaperGateway
+
+        PaperGateway(symbol=args.symbol)
+    else:
+        from bot_trade.gateways import CCXTAdapter
+
+        CCXTAdapter(symbol=args.symbol, sandbox=gw != "live")
+
     device_str = normalize_device(getattr(args, "device", None), os.environ)
     try:
         import torch  # type: ignore

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -9,7 +9,9 @@ python -m bot_trade.tools.eval_run --symbol BTCUSDT --frame 1m --run-id latest -
 
 2. Continuous SAC
 ```bash
-python -m bot_trade.train_rl --algorithm SAC --continuous-env --symbol BTCUSDT --frame 1m --device cpu --n-envs 1 --total-steps 128 --headless --allow-synth --data-dir data_ready --no-monitor
+python -m bot_trade.train_rl --algorithm SAC --continuous-env --gateway paper \
+  --symbol BTCUSDT --frame 1m --device cpu --n-envs 1 --total-steps 128 \
+  --headless --allow-synth --data-dir data_ready --no-monitor
 python -m bot_trade.tools.eval_run --symbol BTCUSDT --frame 1m --run-id latest
 ```
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -4,7 +4,7 @@
 - `python -m py_compile $(git ls-files 'bot_trade/**/*.py' 'bot_trade/*.py')`
 - Run CPU smokes for PPO and SAC; logs contain `[EVAL]` and `[POSTRUN]`.
 - `python -m bot_trade.tools.dev_checks --symbol BTCUSDT --frame 1m --run-id latest` → `[CHECKS] ok=.. warnings=..`
-- `python -m bot_trade.tools.sweep --mode random --n-trials 4 --symbol BTCUSDT --frame 1m --algorithm SAC --continuous-env --headless --allow-synth --data-dir data_ready` → `[SWEEP]` with CSV/MD/JSONL.
+- `python -m bot_trade.tools.sweep --mode random --n-trials 4 --symbol BTCUSDT --frame 1m --algorithm SAC --continuous-env --gateway paper --headless --allow-synth --data-dir data_ready` → `[SWEEP]` with CSV/MD/JSONL.
 - Ensure tearsheet generated for latest run.
 
 ## Artifacts
@@ -24,7 +24,7 @@
 python -m bot_trade.tools.gen_synth_data --symbol BTCUSDT --frame 1m --out data_ready
 python -m bot_trade.train_rl --algorithm PPO --symbol BTCUSDT --frame 1m --device cpu --n-envs 1 --total-steps 128 --headless --allow-synth --data-dir data_ready --no-monitor
 python -m bot_trade.tools.eval_run --symbol BTCUSDT --frame 1m --run-id latest --tearsheet
-python -m bot_trade.tools.sweep --mode random --n-trials 4 --symbol BTCUSDT --frame 1m --algorithm SAC --continuous-env --headless --allow-synth --data-dir data_ready
+python -m bot_trade.tools.sweep --mode random --n-trials 4 --symbol BTCUSDT --frame 1m --algorithm SAC --continuous-env --gateway paper --headless --allow-synth --data-dir data_ready
 python -m bot_trade.tools.dev_checks --symbol BTCUSDT --frame 1m --run-id latest
 ```
 


### PR DESCRIPTION
## Summary
- Introduce in-memory `PaperGateway` with rate limiting and idempotent order IDs
- Add `--gateway` CLI flag and initialize gateway during training to emit `[GATEWAY]` logs
- Update Quickstart and Release guides to show paper-mode workflows

## Testing
- `python -m py_compile $(git ls-files 'bot_trade/**/*.py' 'bot_trade/*.py')`
- `python -m bot_trade.tools.gen_synth_data --symbol BTCUSDT --frame 1m --out data_ready`
- `python -m bot_trade.runners.train_rl --algorithm PPO --symbol BTCUSDT --frame 1m --device cpu --n-envs 1 --total-steps 256 --headless --allow-synth --data-dir data_ready --no-monitor`
- `python -m bot_trade.runners.train_rl --algorithm SAC --continuous-env --gateway paper --symbol BTCUSDT --frame 1m --device cpu --n-envs 1 --total-steps 512 --headless --allow-synth --data-dir data_ready --no-monitor --policy-kwargs '{"net_arch":[256,256],"activation_fn":"ReLU"}'`
- `python -m bot_trade.tools.export_charts --symbol BTCUSDT --frame 1m --run-id latest --debug-export`
- `python -m bot_trade.tools.eval_run --symbol BTCUSDT --frame 1m --run-id latest --tearsheet --gate`
- `python -m bot_trade.tools.sweep --mode random --n-trials 4 --algorithm SAC --continuous-env --symbol BTCUSDT --frame 1m --headless --allow-synth --data-dir data_ready --gate`
- `python -m bot_trade.tools.dev_checks --symbol BTCUSDT --frame 1m --run-id latest`


------
https://chatgpt.com/codex/tasks/task_b_68b8cb38b990832d86c45583f99f993d