### PR TITLE
Add execution realism and evaluation utilities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+on:
+  pull_request:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - run: pip install -r requirements.txt
+      - run: ruff check bot_trade/backtest bot_trade/eval bot_trade/runners bot_trade/tools --fix
+      - run: python -m py_compile $(git ls-files 'bot_trade/**/*.py' 'bot_trade/*.py')
+      - run: PYTHONPATH=. pytest -q tests/unit/test_rate_limit.py tests/unit/test_sandbox_gateway.py tests/unit/test_execution_layer.py tests/unit/test_time_splits.py tests/unit/test_gates.py
+      - run: python -m bot_trade.tools.paths_doctor --strict

--- a/bot_trade/backtest/models.py
+++ b/bot_trade/backtest/models.py
@@ -3,15 +3,32 @@ from dataclasses import dataclass
 
 @dataclass(slots=True)
 class Order:
+    """Simplified order model used for backtests."""
+
     id: str
     side: str
     qty: float
     price: float
     ts: float
+    is_maker: bool = False
+
+
+@dataclass(slots=True)
+class Fill:
+    """Executed order slice."""
+
+    side: str
+    qty: float
+    price: float
+    fee: float
+    slippage_bps: float
+    latency_ms: int
 
 
 @dataclass(slots=True)
 class ExecutionResult:
+    """Aggregate execution outcome."""
+
     status: str
     filled_qty: float
     avg_price: float
@@ -19,3 +36,5 @@ class ExecutionResult:
     ts: float
     slippage_bps: float
     order_id: str | None = None
+    fills: list[Fill] | None = None
+

--- a/bot_trade/eval/eval_run.py
+++ b/bot_trade/eval/eval_run.py
@@ -1,0 +1,41 @@
+"""Thin wrapper around :mod:`bot_trade.tools.eval_run` for unified CLI."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from bot_trade.tools import eval_run as tools_eval_run
+
+from .tearsheet_html import generate_tearsheet
+
+
+def _derive_parts(run_dir: Path) -> tuple[str, str, str]:
+    """Extract symbol, frame and run_id from a run directory."""
+    parts = run_dir.resolve().parts
+    if len(parts) < 3:
+        raise ValueError("run directory must be results/<symbol>/<frame>/<run>")
+    symbol, frame, run_id = parts[-3], parts[-2], parts[-1]
+    if run_id == "latest" and (run_dir.is_symlink() or run_dir.exists()):
+        run_id = Path(run_dir).resolve().name
+    return symbol, frame, run_id
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="Evaluate a run directory")
+    p.add_argument("--run-dir", required=True, type=Path)
+    p.add_argument("--tearsheet-html", action="store_true")
+    args = p.parse_args(argv)
+
+    symbol, frame, run_id = _derive_parts(args.run_dir)
+    # delegate to tools.eval_run
+    cmd = ["--symbol", symbol, "--frame", frame, "--run-id", run_id]
+    if args.tearsheet_html:
+        cmd.append("--tearsheet")
+    rc = tools_eval_run.main(cmd)
+    if args.tearsheet_html:
+        generate_tearsheet(args.run_dir)
+    return rc
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/bot_trade/eval/tearsheet_html.py
+++ b/bot_trade/eval/tearsheet_html.py
@@ -1,0 +1,37 @@
+"""Minimal HTML tearsheet generator."""
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+
+from bot_trade.tools.atomic_io import write_text
+
+
+def _metrics_table(metrics: Mapping[str, float]) -> str:
+    rows = "".join(
+        f"<tr><th>{k}</th><td>{v:.4f}</td></tr>" for k, v in metrics.items()
+    )
+    return f"<table>{rows}</table>"
+
+
+def generate_tearsheet(run_dir: Path) -> Path:
+    """Create a tiny HTML report under ``run_dir``."""
+    summary_path = run_dir / "summary.json"
+    charts_dir = run_dir / "charts"
+    metrics = {}
+    try:
+        with summary_path.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+            metrics = {k: v for k, v in data.items() if isinstance(v, (int, float))}
+    except Exception:
+        pass
+    images = [p.name for p in charts_dir.glob("*.png")] if charts_dir.exists() else []
+    img_html = "".join(f"<img src='charts/{name}' alt='{name}'/>" for name in images)
+    html = f"<html><body>{_metrics_table(metrics)}{img_html}</body></html>"
+    out = run_dir / "tearsheet.html"
+    write_text(out, html)
+    return out
+
+
+__all__ = ["generate_tearsheet"]

--- a/bot_trade/eval/wfa_gate.py
+++ b/bot_trade/eval/wfa_gate.py
@@ -1,13 +1,12 @@
-from __future__ import annotations
 """Walk-forward analysis gate."""
+
+from __future__ import annotations
 
 import argparse
 import csv
-import json
 import random
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List
 
 import matplotlib.pyplot as plt
 import yaml
@@ -24,7 +23,7 @@ class Metrics:
     winrate: float
 
 
-def run_windows(n: int) -> List[Metrics]:
+def run_windows(n: int) -> list[Metrics]:
     return [Metrics(random.random(), random.random(), random.random(), random.random()) for _ in range(n)]
 
 
@@ -35,10 +34,10 @@ def main() -> None:
     ap.add_argument("--symbol", required=True)
     ap.add_argument("--frame", required=True)
     ap.add_argument("--windows", type=int, default=3)
-    ap.add_argument("--step", type=float, default=0.5)
+    ap.add_argument("--embargo", type=float, default=0.0)
     args = ap.parse_args()
 
-    with open(args.config, "r", encoding="utf-8") as fh:
+    with open(args.config, encoding="utf-8") as fh:
         cfg = yaml.safe_load(fh)
     metrics = run_windows(args.windows)
     rows = []

--- a/bot_trade/runners/live_dry_run.py
+++ b/bot_trade/runners/live_dry_run.py
@@ -1,22 +1,22 @@
-from __future__ import annotations
 """Live dry-run runner consuming live prices and executing paper trades."""
 
+from __future__ import annotations
+
 import argparse
+import csv
 import random
 import time
 from pathlib import Path
-from typing import Callable
 
 import yaml
 
 from bot_trade.data.live_feed import LiveFeed
-from bot_trade.gateways.paper import PaperGateway
-from bot_trade.tools.atomic_io import append_jsonl, write_json
+from bot_trade.tools.atomic_io import append_jsonl, write_json, write_text
 from bot_trade.tools.force_utf8 import force_utf8
 
 
 def _load_config(path: str) -> dict:
-    with open(path, "r", encoding="utf-8") as fh:
+    with open(path, encoding="utf-8") as fh:
         return yaml.safe_load(fh)
 
 
@@ -28,6 +28,7 @@ def main() -> None:
     ap.add_argument("--frame", required=True)
     ap.add_argument("--gateway", default="paper")
     ap.add_argument("--model")
+    ap.add_argument("--model-optional", action="store_true")
     ap.add_argument("--duration", type=int, default=60)
     ap.add_argument("--config", default="config/live_dry_run.yaml")
     args = ap.parse_args()
@@ -35,7 +36,13 @@ def main() -> None:
     cfg = _load_config(args.config)
     ecfg = cfg[args.exchange]
     feed = LiveFeed(ecfg.get("ws"), ecfg["rest"] + ecfg["price_path"], interval=1.0)
-    gw = PaperGateway(args.symbol)
+
+    if args.model and Path(args.model).exists():
+        pass  # placeholder for model loading
+    elif not args.model_optional:
+        raise SystemExit("model required")
+    else:
+        print("[WARN] model missing, falling back to random policy")
 
     run_dir = Path("results") / args.symbol / args.frame / str(int(time.time()))
     metrics = []
@@ -52,13 +59,21 @@ def main() -> None:
             time.sleep(0.5)
     except KeyboardInterrupt:
         pass
-
-    summary = {"ticks": len(metrics)}
-    run_dir.mkdir(parents=True, exist_ok=True)
-    write_json(run_dir / "summary.json", summary)
-    for m in metrics:
-        append_jsonl(run_dir / "risk_flags.jsonl", m)
-    write_json(run_dir / "metrics.json", metrics)
+    finally:
+        run_dir.mkdir(parents=True, exist_ok=True)
+        summary = {"ticks": len(metrics)}
+        write_json(run_dir / "summary.json", summary)
+        for m in metrics:
+            append_jsonl(run_dir / "risk_flags.jsonl", m)
+        # metrics.csv
+        csv_path = run_dir / "metrics.csv"
+        if metrics:
+            with csv_path.open("w", newline="", encoding="utf-8") as fh:
+                w = csv.DictWriter(fh, fieldnames=metrics[0].keys())
+                w.writeheader()
+                w.writerows(metrics)
+        else:
+            write_text(csv_path, "")
 
 
 if __name__ == "__main__":

--- a/config/execution.yaml
+++ b/config/execution.yaml
@@ -1,12 +1,13 @@
 mode: backtest
-model: fixed_bp
-params:
-  bp: 0
+slippage:
+  model: fixed_bps
+  bps: 0
 latency_ms: 0
 allow_partial: true
 fees:
-  maker: 0.0
-  taker: 0.0
+  maker_bps: 0.0
+  taker_bps: 0.0
+  min_fee: 0.0
 lot: 0.0
 min_notional: 0.0
 max_spread_bp: 0.0

--- a/docs/dev_notes.md
+++ b/docs/dev_notes.md
@@ -1,3 +1,8 @@
 [2024-05-31 00:00] initial notes file created.
 [2024-05-31 12:00] execution_layer / time_splits / gates — added deterministic execution simulator with fees/slippage/latency/partials, new chronological split helpers, and threshold gate with pass ratios.
 [2024-05-31 12:30] style pass — fixed type hints and import ordering per ruff.
+[2025-06-01 00:00] E2E Integration after ExecutionLayer/TimeSplits/Gates —
+- Added maker/min fee handling and fill logging in backtest ExecutionLayer.
+- Introduced eval_run wrapper, HTML tearsheet, gate fail-hard promotion, live dry-run fallbacks, paths doctor and CI workflow.
+- Risks: limited real exchange testing; paths doctor only checks basic structure.
+- Next: expand lint coverage gradually, enhance live feed resilience.

--- a/docs/e2e_quickstart.md
+++ b/docs/e2e_quickstart.md
@@ -1,0 +1,22 @@
+# E2E Quickstart
+
+1. Train a small model:
+   ```bash
+   python bot_trade/train_rl.py --config config/train_btcusdt_1m.yaml --max-steps 4000 --seed 7
+   ```
+2. Evaluate the latest run and produce a tearsheet:
+   ```bash
+   python -m bot_trade.eval.eval_run --run-dir results/BTCUSDT/1m/latest --tearsheet-html
+   ```
+3. Apply walk-forward gate:
+   ```bash
+   python -m bot_trade.eval.wfa_gate --config config/wfa.yaml --symbol BTCUSDT --frame 1m --windows 3 --embargo 0.05
+   ```
+4. Optional live dry run with model fallback:
+   ```bash
+   python -m bot_trade.runners.live_dry_run --exchange binance --symbol BTCUSDT --frame 1m --gateway paper --model results/BTCUSDT/1m/latest/artifacts/best_model.zip --duration 120 --model-optional
+   ```
+5. Verify paths:
+   ```bash
+   python -m bot_trade.tools.paths_doctor --strict
+   ```

--- a/tests/unit/test_execution_layer.py
+++ b/tests/unit/test_execution_layer.py
@@ -19,3 +19,13 @@ def test_execution_layer_basic():
     assert res.fees == 1  # min fee dominates
     assert res.ts == 1.0  # latency applied
     assert res.slippage_bps == 10
+
+
+def test_maker_fee_and_min_fee():
+    cfg = {"fees": {"maker_bps": 1, "taker_bps": 5, "min_fee": 0.5}}
+    layer = ExecutionLayer(cfg, seed=1)
+    order = Order(id="2", side="sell", qty=2, price=50.0, ts=0.0, is_maker=True)
+    res = layer.apply(order, {"price": 50.0})
+    assert res.status == "filled"
+    # maker fee 1 bps -> 0.01% * value
+    assert res.fees == max(50.0 * 2 * 0.0001, 0.5)

--- a/tests/unit/test_gates.py
+++ b/tests/unit/test_gates.py
@@ -1,3 +1,5 @@
+import pytest
+
 from bot_trade.eval.gates import threshold_gate
 
 
@@ -13,3 +15,6 @@ def test_gate_pass_and_fail(tmp_path):
     assert not res2.passed
     assert set(res2.reasons) == {"min_sharpe", "min_sortino", "max_drawdown", "min_winrate"}
     assert res2.pass_ratio == 0.0
+
+    with pytest.raises(SystemExit):
+        threshold_gate(metrics2, thresholds, fail_hard=True)


### PR DESCRIPTION
## Summary
- model fills now track maker/taker fees and log per-fill execution
- add gate fail-hard promotion, eval wrapper and HTML tearsheet
- support optional models in live dry-run and basic results path doctor

## Testing
- `ruff check bot_trade/backtest/execution_layer.py bot_trade/backtest/models.py bot_trade/eval/gates.py bot_trade/eval/wfa_gate.py bot_trade/eval/eval_run.py bot_trade/eval/tearsheet_html.py bot_trade/runners/live_dry_run.py bot_trade/tools/paths_doctor.py --fix`
- `python -m py_compile $(git ls-files 'bot_trade/**/*.py' 'bot_trade/*.py')`
- `PYTHONPATH=. pytest -q tests/unit/test_rate_limit.py tests/unit/test_sandbox_gateway.py tests/unit/test_execution_layer.py tests/unit/test_time_splits.py tests/unit/test_gates.py`
- `PYTHONPATH=. python bot_trade/train_rl.py --config config/train_btcusdt_1m.yaml --total-steps 4000 --seed 7`
- `python -m bot_trade.eval.eval_run --run-dir results/BTCUSDT/1m/latest --tearsheet-html`
- `python -m bot_trade.eval.wfa_gate --config config/wfa.yaml --symbol BTCUSDT --frame 1m --windows 3 --embargo 0.05`
- `python -m bot_trade.runners.live_dry_run --exchange binance --symbol BTCUSDT --frame 1m --gateway paper --model results/BTCUSDT/1m/latest/artifacts/best_model.zip --duration 1 --model-optional`
- `python -m bot_trade.tools.paths_doctor --strict`

------
https://chatgpt.com/codex/tasks/task_b_68b8e73b32b8832d8953f0f08403dfe6