### PR TITLE
feat: robust live feed polling

### DIFF
--- a/bot_trade/data/live_feed.py
+++ b/bot_trade/data/live_feed.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import math
 import random
 import threading
 import time
@@ -20,13 +21,22 @@ except Exception:  # pragma: no cover - optional
 
 class LiveFeed:
     def __init__(
-        self, ws_url: Optional[str], http_url: str, interval: float = 1.0
+        self,
+        ws_url: Optional[str],
+        http_url: str,
+        interval: float = 1.0,
+        *,
+        alpha: float = 0.3,
+        bootstrap_price: Optional[float] = None,
     ) -> None:
         self.ws_url = ws_url
         self.http_url = http_url
         self.interval = interval
         # allow up to two polls per second; shared limiter ensures spacing
         self.limiter = RateLimiter(capacity=1, refill_time=0.5)
+        self.alpha = alpha
+        self.last_price: Optional[float] = bootstrap_price
+        self.smooth_price: Optional[float] = bootstrap_price
 
     # ------------------------------------------------------------------
     def stream(self, symbol: str, on_tick: Callable[[float], None]) -> None:
@@ -64,9 +74,11 @@ class LiveFeed:
 
     def _http_loop(self, symbol: str, on_tick: Callable[[float], None]) -> None:
         last = time.time()
+        bad_seq = 0
+        backoff_ms = 250
         while True:
             self.limiter.acquire()
-            price = 0.0
+            price: Optional[float] = None
             try:
                 r = requests.get(self.http_url, params={"symbol": symbol})
                 data = r.json()
@@ -74,11 +86,41 @@ class LiveFeed:
                     data.get("price")
                     or data.get("result", {}).get("list", [{}])[0].get("lastPrice", 0)
                 )
-                on_tick(price)
             except Exception:
-                pass
+                price = None
+
+            if price is None or not math.isfinite(price) or price <= 0:
+                bad_seq += 1
+                if self.last_price is None:
+                    sleep = min(backoff_ms, 2000) / 1000.0
+                    print(f"[LIVE] bad_price; skipping; backoff_ms={int(sleep * 1000)}")
+                    backoff_ms = int(min(backoff_ms * 1.6, 2000))
+                    time.sleep(sleep)
+                    continue
+                price = self.last_price
+            else:
+                self.last_price = price
+                bad_seq = 0
+                backoff_ms = 250
+
+            if self.smooth_price is None:
+                self.smooth_price = price
+            else:
+                self.smooth_price = (
+                    self.alpha * price + (1 - self.alpha) * self.smooth_price
+                )
+            ps = self.smooth_price
+            on_tick(ps)
+
             now = time.time()
             drift = int((now - last - self.interval) * 1000)
-            print(f"[LIVE] poll price={price} drift_ms={drift}")
+            sleep = self.interval * (0.5 + random.random() * 0.5)
+            if bad_seq:
+                sleep = max(sleep, backoff_ms / 1000.0)
+                backoff_ms = int(min(backoff_ms * 1.6, 2000))
+            print(
+                f"[LIVE] poll price={price:.2f} smooth={ps:.2f} drift_ms={drift} "
+                f"bad_seq={bad_seq} sleep_ms={int(sleep * 1000)}"
+            )
             last = now
-            time.sleep(self.interval * (0.5 + random.random() * 0.5))
+            time.sleep(sleep)

--- a/docs/dev_notes.md
+++ b/docs/dev_notes.md
@@ -17,3 +17,9 @@
 - WHY: consolidate improvements for stable base and ensure predictable tooling.
 - RISKS: HTTP polling may hit API limits; paths_doctor hints assume default configs.
 - NEXT: extend policies for live trading and enhance fallback resiliency.
+[2025-10-14 00:00] [Live Feed Patch] Robust polling: bad-price guards, EWMA smoothing, last-known fallback, limiter-aware backoff.
+- WHAT: added price validation with last-price fallback, EWMA smoothing and rate limiter-aware exponential backoff.
+- WHY: prevent invalid ticks from breaking runs and stabilize metrics under network limits.
+- RISKS: smoothing may lag fast markets; aggressive backoff delays recovery.
+- MIGRATION: optional --bootstrap-price seeds initial price; no other steps.
+- NEXT: tune smoothing factor and expand real exchange coverage.

--- a/docs/e2e_quickstart.md
+++ b/docs/e2e_quickstart.md
@@ -16,12 +16,15 @@
    ```bash
    python -m bot_trade.eval.wfa_gate --config config/wfa.yaml --symbol BTCUSDT --frame 1m --windows 3 --embargo 0.05 --profile smoke
    ```
-5. Optional live dry run with model fallback:
+5. Optional live dry run with model fallback and bootstrap price:
    ```bash
    python -m bot_trade.runners.live_dry_run --exchange binance --symbol BTCUSDT --frame 1m \
-     --gateway paper --model results/BTCUSDT/1m/latest/artifacts/best_model.zip --duration 90 --model-optional
+     --gateway paper --model results/BTCUSDT/1m/latest/artifacts/best_model.zip --duration 90 \
+     --bootstrap-price 27000 --model-optional
    ```
+   The feed applies EWMA smoothing and exponential backoff when network limits hit.
 6. Verify paths:
    ```bash
    python -m bot_trade.tools.paths_doctor --symbol BTCUSDT --frame 1m --strict
    ```
+   If the live run only produced HoldPolicy ticks, paths_doctor may hint about missing live charts.

--- a/tests/unit/test_live_feed.py
+++ b/tests/unit/test_live_feed.py
@@ -1,0 +1,81 @@
+import time
+from typing import List
+
+import pytest
+import requests
+
+from bot_trade.data.live_feed import LiveFeed
+
+
+class DummyResp:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+def test_bad_price_sequence(monkeypatch):
+    seq = [
+        {"price": 10},
+        {"price": None},
+        {"price": float("nan")},
+    ]
+    calls = {"i": 0}
+
+    def fake_get(url, params=None):
+        payload = seq[min(calls["i"], len(seq) - 1)]
+        calls["i"] += 1
+        return DummyResp(payload)
+
+    sleeps: List[float] = []
+
+    def fake_sleep(t):
+        sleeps.append(t)
+        if len(sleeps) >= 3:
+            raise RuntimeError
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    monkeypatch.setattr(time, "sleep", fake_sleep)
+
+    feed = LiveFeed(None, "http://test", interval=0.1, alpha=1.0)
+    monkeypatch.setattr(feed.limiter, "acquire", lambda *a, **k: None)
+    prices: List[float] = []
+
+    def on_tick(p: float) -> None:
+        prices.append(p)
+
+    with pytest.raises(RuntimeError):
+        feed._http_loop("BTC", on_tick)
+
+    assert prices == [10, 10, 10]
+    assert sleeps[1] < sleeps[2]
+
+
+def test_ewma_smoothing(monkeypatch):
+    seq = [{"price": 10}, {"price": 11}, {"price": 13}]
+    calls = {"i": 0}
+
+    def fake_get(url, params=None):
+        payload = seq[calls["i"]]
+        calls["i"] += 1
+        return DummyResp(payload)
+
+    def fake_sleep(t):
+        if calls["i"] >= 3:
+            raise RuntimeError
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    monkeypatch.setattr(time, "sleep", fake_sleep)
+
+    feed = LiveFeed(None, "http://test", interval=0.1, alpha=0.3)
+    monkeypatch.setattr(feed.limiter, "acquire", lambda *a, **k: None)
+    prices: List[float] = []
+
+    def on_tick(p: float) -> None:
+        prices.append(p)
+
+    with pytest.raises(RuntimeError):
+        feed._http_loop("BTC", on_tick)
+
+    assert prices == pytest.approx([10, 10.3, 11.11], rel=1e-2)

--- a/tests/unit/test_live_runner.py
+++ b/tests/unit/test_live_runner.py
@@ -1,0 +1,47 @@
+import sys
+from pathlib import Path
+
+import pytest
+import sys
+
+from bot_trade.runners import live_dry_run
+
+
+class NoPriceFeed:
+    def __init__(self, *args, **kwargs):
+        self.interval = 0.01
+        self.last_price = None
+
+    def stream(self, symbol, on_tick):
+        # never emits price
+        pass
+
+
+def test_no_valid_price_for_10(tmp_path, monkeypatch, capsys):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(live_dry_run, "LiveFeed", NoPriceFeed)
+    monkeypatch.setattr(
+        live_dry_run, "_load_config", lambda _: {"binance": {"rest": "", "price_path": ""}}
+    )
+    argv = [
+        "prog",
+        "--exchange",
+        "binance",
+        "--symbol",
+        "BTCUSDT",
+        "--frame",
+        "1m",
+        "--duration",
+        "1",
+        "--model-optional",
+        "--config",
+        "cfg",
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+    live_dry_run.main()
+    out = capsys.readouterr().out
+    assert "no valid price" in out
+    run_dir = next(Path("results").rglob("summary.json")).parent
+    assert (run_dir / "summary.json").exists()
+    assert (run_dir / "metrics.csv").exists()
+    assert (run_dir / "risk_flags.jsonl").exists()


### PR DESCRIPTION
## Summary
- guard live HTTP polling against invalid prices with last-price fallback, EWMA smoothing and limiter-aware backoff
- add bootstrap price option and HoldPolicy fallback to live_dry_run runner
- document bootstrap usage and smoothing/backoff details

## Testing
- `PYTHONPATH=. pytest tests/unit -q`
- `python -m bot_trade.runners.live_dry_run --exchange binance --symbol BTCUSDT --frame 1m --duration 2 --model-optional --bootstrap-price 27000`


------
https://chatgpt.com/codex/tasks/task_b_68b8f694f4e4832da43bf8b33acc671c