### PR TITLE
Final merge: live tests, logs, CI, docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
         with:
           python-version: '3.11'
       - run: pip install -r requirements.txt
-      - run: ruff check bot_trade/backtest bot_trade/eval bot_trade/runners bot_trade/tools --fix
+      - run: ruff check bot_trade/backtest bot_trade/eval bot_trade/runners bot_trade/tools tests/unit --fix
       - run: python -m py_compile $(git ls-files 'bot_trade/**/*.py' 'bot_trade/*.py')
-      - run: PYTHONPATH=. pytest -q tests/unit/test_rate_limit.py tests/unit/test_sandbox_gateway.py tests/unit/test_execution_layer.py tests/unit/test_time_splits.py tests/unit/test_gates.py
-      - run: python -m bot_trade.tools.paths_doctor --strict
+      - run: PYTHONPATH=. pytest -q
+      - run: PYTHONPATH=. python -m bot_trade.tools.paths_doctor --symbol BTCUSDT --frame 1m --strict

--- a/bot_trade/backtest/execution_layer.py
+++ b/bot_trade/backtest/execution_layer.py
@@ -103,16 +103,9 @@ class ExecutionLayer:
         )
 
         print(
-            "FILL",
-            f"side={order.side.upper()}",
-            f"qty={filled_qty}",
-            f"px={fill_price}",
-            f"fee={fee}",
-            f"maker={int(order.is_maker)}",
-            f"min_fee={int(min_applied)}",
-            f"slip_bps={slippage_bps}",
-            f"latency_ms={latency_ms}",
-            f"ts={ts}",
+            f"FILL side={order.side} qty={filled_qty} px={fill_price} fee={fee} "
+            f"maker={int(order.is_maker)} min_fee={int(min_applied)} "
+            f"slip_bps={slippage_bps} latency_ms={latency_ms} ts={ts}"
         )
 
         return ExecutionResult(

--- a/bot_trade/eval/wfa_gate.py
+++ b/bot_trade/eval/wfa_gate.py
@@ -30,7 +30,10 @@ def run_windows(n: int) -> list[Metrics]:
 
 def main() -> None:
     force_utf8()
-    ap = argparse.ArgumentParser(description="WFA gate")
+    ap = argparse.ArgumentParser(
+        description="WFA gate",
+        epilog="Unknown args are ignored with a warning",
+    )
     ap.add_argument("--config", required=True)
     ap.add_argument("--symbol", required=True)
     ap.add_argument("--frame", required=True)

--- a/bot_trade/tools/paths_doctor.py
+++ b/bot_trade/tools/paths_doctor.py
@@ -7,57 +7,62 @@ from pathlib import Path
 from bot_trade.tools.force_utf8 import force_utf8
 
 REQUIRED_FILES = {"metrics.csv", "summary.json", "risk_flags.jsonl"}
-REQUIRED_DIRS = {"charts", "artifacts"}
 
 
-def _hint(name: str, run: Path, symbol: str, frame: str) -> str:
-    if name == "best_model.zip":
-        return (
-            "python bot_trade/train_rl.py --config "
-            f"config/train_{symbol.lower()}_{frame}.yaml --data-dir <dir>"
-        )
-    return f"python -m bot_trade.eval.eval_run --run-dir {run}"
+def _remediation(symbol: str, frame: str) -> None:
+    print(
+        "Run: python -m bot_trade.tools.gen_synth_data --symbol "
+        f"{symbol} --frame {frame} --days 1 --out data_ready"
+    )
+    print(
+        "Then: python bot_trade/train_rl.py --config "
+        f"config/train_{symbol.lower()}_{frame}.yaml --max-steps 4000 --seed 7 --data-dir data_ready"
+    )
+    print(
+        "Then: python -m bot_trade.eval.eval_run --run-dir "
+        f"results/{symbol}/{frame}/latest --tearsheet-html"
+    )
 
 
 def _check_run(run: Path, symbol: str, frame: str) -> bool:
     ok = True
     for name in REQUIRED_FILES:
         if not (run / name).exists():
-            print(f"[PATHS] missing {name} in {run} -> {_hint(name, run, symbol, frame)}")
+            print(f"[PATHS] missing {name} in {run}")
             ok = False
     charts = run / "charts"
     if not charts.exists() or not any(charts.glob("*.png")):
-        print(
-            f"[PATHS] missing charts/*.png in {run} -> {_hint('charts', run, symbol, frame)}"
-        )
+        print(f"[PATHS] missing charts/*.png in {run}")
         ok = False
     artifacts = run / "artifacts" / "best_model.zip"
     if not artifacts.exists():
-        print(
-            f"[PATHS] missing artifacts/best_model.zip in {run} -> {_hint('best_model.zip', run, symbol, frame)}"
-        )
+        print(f"[PATHS] missing artifacts/best_model.zip in {run}")
         ok = False
+    if not ok:
+        _remediation(symbol, frame)
     return ok
 
 
 def main(argv: list[str] | None = None) -> int:
     ap = argparse.ArgumentParser(
         description="Validate results layout",
-        epilog="Example: python -m bot_trade.tools.paths_doctor --symbol BTCUSDT --frame 1m",
+        epilog="Example: python -m bot_trade.tools.paths_doctor --symbol BTCUSDT --frame 1m --strict",
     )
     ap.add_argument("--symbol", required=True, help="Trading symbol")
     ap.add_argument("--frame", required=True, help="Time frame, e.g. 1m")
     ap.add_argument("--run-id", default="latest", help="Run id or 'latest'")
     ap.add_argument("--strict", action="store_true", help="Exit 2 if missing")
-    ns = ap.parse_args(argv)
+    ns, extras = ap.parse_known_args(argv)
+    if extras:
+        print(f"[WARN] ignoring extras: {' '.join(extras)}")
 
     run = Path("results") / ns.symbol / ns.frame / ns.run_id
     if run.is_symlink() or ns.run_id == "latest":
         if run.exists():
             run = run.resolve()
     if not run.exists():
-        hint = _hint("best_model.zip", run, ns.symbol, ns.frame)
-        print(f"[PATHS] run directory not found: {run} -> {hint}")
+        print(f"[PATHS] run directory not found: {run}")
+        _remediation(ns.symbol, ns.frame)
         return 2 if ns.strict else 0
 
     ok = _check_run(run, ns.symbol, ns.frame)

--- a/docs/dev_notes.md
+++ b/docs/dev_notes.md
@@ -23,3 +23,9 @@
 - RISKS: smoothing may lag fast markets; aggressive backoff delays recovery.
 - MIGRATION: optional --bootstrap-price seeds initial price; no other steps.
 - NEXT: tune smoothing factor and expand real exchange coverage.
+[2025-10-15 00:00] [Final Merge] Import live tests, unify logs, tighten CI order, quickstart polish.
+- WHAT: merged live feed/runner tests, standardized LIVE/FILL logs, documented E2E commands and CLI flags, tightened CI to lint, compile, test, and validate paths.
+- WHY: ensure reproducible end-to-end workflow and grep-friendly logging for final release.
+- RISKS: stricter CI may fail on legacy branches; log parsing tools must handle new format.
+- MIGRATION: rerun quickstart to regenerate results; update any custom parsers for new logs.
+- NEXT: broaden exchange coverage and integrate real order execution.

--- a/docs/e2e_quickstart.md
+++ b/docs/e2e_quickstart.md
@@ -2,13 +2,13 @@
 
 1. Generate tiny synthetic data:
    ```bash
-   python -m bot_trade.tools.gen_synth_data --symbol BTCUSDT --frame 1m --days 3 --out data_ready
+   python -m bot_trade.tools.gen_synth_data --symbol BTCUSDT --frame 1m --days 1 --out data_ready
    ```
 2. Train a small model:
    ```bash
    python bot_trade/train_rl.py --config config/train_btcusdt_1m.yaml --max-steps 4000 --seed 7 --data-dir data_ready
    ```
-3. Evaluate the latest run and produce a tearsheet:
+3. Evaluate the latest run and produce a tearsheet (PDF optional):
    ```bash
    python -m bot_trade.eval.eval_run --run-dir results/BTCUSDT/1m/latest --tearsheet-html
    ```
@@ -19,8 +19,7 @@
 5. Optional live dry run with model fallback and bootstrap price:
    ```bash
    python -m bot_trade.runners.live_dry_run --exchange binance --symbol BTCUSDT --frame 1m \
-     --gateway paper --model results/BTCUSDT/1m/latest/artifacts/best_model.zip --duration 90 \
-     --bootstrap-price 27000 --model-optional
+     --gateway paper --duration 90 --model-optional --bootstrap-price 27000
    ```
    The feed applies EWMA smoothing and exponential backoff when network limits hit.
 6. Verify paths:

--- a/tests/unit/test_live_runner.py
+++ b/tests/unit/test_live_runner.py
@@ -1,28 +1,46 @@
 import sys
+import time
 from pathlib import Path
-
-import pytest
-import sys
 
 from bot_trade.runners import live_dry_run
 
 
-class NoPriceFeed:
+class OneTickFeed:
     def __init__(self, *args, **kwargs):
         self.interval = 0.01
         self.last_price = None
 
     def stream(self, symbol, on_tick):
-        # never emits price
+        self.last_price = 100.0
+        on_tick(100.0)
+
+
+class NoPriceFeed:
+    def __init__(self, *args, **kwargs):
+        self.interval = 0.1
+        self.last_price = None
+
+    def stream(self, symbol, on_tick):
         pass
 
 
-def test_no_valid_price_for_10(tmp_path, monkeypatch, capsys):
+def test_model_optional_runs(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr(live_dry_run, "LiveFeed", NoPriceFeed)
+    monkeypatch.setattr(live_dry_run, "LiveFeed", OneTickFeed)
     monkeypatch.setattr(
         live_dry_run, "_load_config", lambda _: {"binance": {"rest": "", "price_path": ""}}
     )
+    monkeypatch.setattr(time, "sleep", lambda s: None)
+
+    def time_gen():
+        t = 0.0
+        while True:
+            t += 1.0
+            yield t
+
+    tg = time_gen()
+    monkeypatch.setattr(time, "time", lambda: next(tg))
+
     argv = [
         "prog",
         "--exchange",
@@ -34,8 +52,47 @@ def test_no_valid_price_for_10(tmp_path, monkeypatch, capsys):
         "--duration",
         "1",
         "--model-optional",
-        "--config",
-        "cfg",
+        "--bootstrap-price",
+        "27000",
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+    live_dry_run.main()
+
+    run_dir = next(Path("results").rglob("summary.json")).parent
+    log = (run_dir / "logs" / "run.log").read_text()
+    assert "[LIVE] tick=" in log
+    assert (run_dir / "metrics.csv").exists()
+    assert (run_dir / "risk_flags.jsonl").exists()
+
+
+def test_hold_policy_after_bad_polls(tmp_path, monkeypatch, capsys):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(live_dry_run, "LiveFeed", NoPriceFeed)
+    monkeypatch.setattr(
+        live_dry_run, "_load_config", lambda _: {"binance": {"rest": "", "price_path": ""}}
+    )
+    monkeypatch.setattr(time, "sleep", lambda s: None)
+
+    def time_gen():
+        t = 0.0
+        while True:
+            t += 0.2
+            yield t
+
+    tg = time_gen()
+    monkeypatch.setattr(time, "time", lambda: next(tg))
+
+    argv = [
+        "prog",
+        "--exchange",
+        "binance",
+        "--symbol",
+        "BTCUSDT",
+        "--frame",
+        "1m",
+        "--duration",
+        "2",
+        "--model-optional",
     ]
     monkeypatch.setattr(sys, "argv", argv)
     live_dry_run.main()


### PR DESCRIPTION
## Summary
- add live feed and runner unit tests covering smoothing, backoff, model-optional path, and HoldPolicy fallback
- standardize LIVE/FILL log lines and tee to run logs
- document end-to-end quickstart and tighten CI order (ruff, compile, pytest, paths_doctor)

## Testing
- `ruff check bot_trade/backtest/execution_layer.py bot_trade/runners/live_dry_run.py bot_trade/eval/wfa_gate.py bot_trade/tools/paths_doctor.py tests/unit/test_live_feed.py tests/unit/test_live_runner.py --fix`
- `python -m py_compile bot_trade/backtest/execution_layer.py bot_trade/runners/live_dry_run.py bot_trade/eval/wfa_gate.py bot_trade/tools/paths_doctor.py tests/unit/test_live_feed.py tests/unit/test_live_runner.py`
- `PYTHONPATH=. pytest -q`
- `python -m bot_trade.tools.gen_synth_data --symbol BTCUSDT --frame 1m --days 1 --out data_ready`
- `python bot_trade/train_rl.py --config config/train_btcusdt_1m.yaml --max-steps 4000 --seed 7 --data-dir data_ready`
- `python -m bot_trade.eval.eval_run --run-dir results/BTCUSDT/1m/latest --tearsheet-html`
- `python -m bot_trade.eval.wfa_gate --config config/wfa.yaml --symbol BTCUSDT --frame 1m --windows 3 --embargo 0.05 --profile smoke`
- `python -m bot_trade.runners.live_dry_run --exchange binance --symbol BTCUSDT --frame 1m --gateway paper --duration 90 --model-optional --bootstrap-price 27000`
- `PYTHONPATH=. python -m bot_trade.tools.paths_doctor --symbol BTCUSDT --frame 1m --strict` *(fails: missing metrics, summary, model)*

------
https://chatgpt.com/codex/tasks/task_b_68b8f9bd84f8832d8cca2b68f0a76d8b