### PR TITLE
feat(ui): expose dev notes and safer runner

### DIFF
--- a/docs/dev_notes.md
+++ b/docs/dev_notes.md
@@ -40,3 +40,8 @@
 - WHY: enable desktop orchestration of training, tools, and live runs.
 - RISKS: limited real-trading coverage; minimal log/error handling.
 - NEXT: enrich controls, metrics charts, and sandbox safety tests.
+[2025-10-17 00:00] UI Panel v0 MVP → v1 Controls —
+- WHAT: expanded panel with dev-notes preview, tee_path runner API and safer stop_process_tree.
+- WHY: improve traceability and reliability for multi-run orchestration.
+- RISKS: stop handling may miss zombie children on exotic platforms.
+- NEXT: surface metrics charts and sandbox key validation.

--- a/docs/ui_panel.md
+++ b/docs/ui_panel.md
@@ -2,14 +2,35 @@
 
 Minimal PySimpleGUI control panel for orchestrating training and tooling.
 
-## Usage
+## Install
+
+```bash
+pip install -r requirements.txt  # includes PySimpleGUI, psutil, watchdog, pyyaml
+```
+
+## Launch
 
 ```bash
 python -m bot_trade.ui.panel
 ```
 
-- Configure training parameters in **Run Train** tab.
-- Use **Data & Tools** for maintenance scripts.
-- Logs appear in **Logs & Errors** tab.
+## Tabs
 
-Configuration is saved to `bot_trade/ui/panel_config.yaml` on exit.
+- **Run Train** – set symbol/frame/algorithm and launch trainings. Each run streams logs and can be stopped independently.
+- **Eval & WFA** – run evaluation helpers on completed results.
+- **Live (Paper/Sandbox)** – guarded entry points for paper or sandbox live modes.
+- **Data & Tools** – whitelisted maintenance scripts such as synthetic data generation.
+- **Logs & Errors** – switch between run logs and copy the last 200 lines.
+- **Config** – environment key status and latest developer-note entry.
+
+State is saved to `bot_trade/ui/panel_config.yaml` on exit so selections persist.
+
+## Sandbox notes
+
+Sandbox live trading is disabled unless testnet API keys are present and the consent box is checked.
+
+## Troubleshooting
+
+- Missing results artefacts → run a training first.
+- "⚠️" on API keys → export the required environment variables.
+- GPU not detected → panel defaults to CPU; select `cpu` explicitly if needed.

--- a/tests/ui/test_runner.py
+++ b/tests/ui/test_runner.py
@@ -11,12 +11,12 @@ def test_runner_start_stop(tmp_path):
     pid = runner.start_command(
         ["python", "-c", "import time,sys; print('hello'); sys.stdout.flush(); time.sleep(1)"],
         run_id="echo",
-        tee_to=str(log_path),
+        tee_path=str(log_path),
         log_queue=log_queue,
     )
     time.sleep(0.2)
     assert log_path.exists()
     line = log_queue.get(timeout=2)
     assert "hello" in line["line"]
-    res = runner.stop_process(pid)
+    res = runner.stop_process_tree(pid)
     assert res["stopped"]


### PR DESCRIPTION
## Summary
- show latest developer note in panel Config tab
- switch runner API to `tee_path` and add `stop_process_tree`
- document panel install/launch and add dev notes entry

## Testing
- `PYTHONPATH=. pytest tests/ui/test_runner.py::test_runner_start_stop -q`
- `PYTHONPATH=. pytest tests/ui/test_whitelist.py::test_reject_non_whitelisted -q`
- `PYTHONPATH=. pytest tests/ui/test_results_watcher.py::test_results_watcher_detects_metrics -q`
- `PYTHONPATH=. pytest tests/ui -q`


------
https://chatgpt.com/codex/tasks/task_b_68b908ed4100832db8f62992c5b5dfb1