### PR TITLE
feat: add market data collectors and signal pipeline

### DIFF
--- a/CHANGE_NOTES.md
+++ b/CHANGE_NOTES.md
@@ -527,3 +527,9 @@ PY`
 - **Rationale**: finalized TD3/TQC builders with SAC-style guards and meta, expanded regime detection and adaptive controller, and introduced runtime risk rule registry with JSONL logging and callback wiring.
 - **Risks**: overly strict risk rules may halt trading; new YAML schemas may break old configs.
 - **Test Steps**: `python -m py_compile bot_trade/**/*.py`; `python -m bot_trade.tools.gen_synth_data --symbol BTCUSDT --frame 1m --out data_ready`; `python -m bot_trade.train_rl --algorithm TD3 --symbol BTCUSDT --frame 1m --total-steps 2 --headless --allow-synth --data-dir data_ready`; `python -m bot_trade.train_rl --algorithm TQC --symbol BTCUSDT --frame 1m --total-steps 2 --headless --allow-synth --data-dir data_ready`; `python -m bot_trade.train_rl --algorithm SAC --symbol BTCUSDT --frame 1m --adaptive-spec config/adaptive.yml --regime-log --total-steps 100 --headless --allow-synth --data-dir data_ready`; `python -m bot_trade.train_rl --algorithm SAC --symbol BTCUSDT --frame 1m --risk-spec config/risk.yml --safety-every 1 --total-steps 100 --headless --allow-synth --data-dir data_ready`
+
+## 2025-10-21
+- **Files**: bot_trade/data/collectors/base.py, bot_trade/data/collectors/ccxt_collector.py, bot_trade/data/collectors/csv_parquet_collector.py, bot_trade/strat/strategy_features.py, bot_trade/config/rl_args.py, bot_trade/config/rl_builders.py, config/signals.yml, DEV_NOTES.md, CHANGE_NOTES.md
+- **Rationale**: introduce pluggable market data collectors, YAML-driven signal pipeline, and expose data-source and advanced TD3/TQC CLI flags with clearer TQC dependency guidance.
+- **Risks**: ccxt dependency optional; mis-specified signal configs may lead to empty feature frames.
+- **Test Steps**: `python -m py_compile $(git ls-files 'bot_trade/**/*.py' 'bot_trade/*.py')`; `python -m bot_trade.train_rl --help | head -n 60`

--- a/DEV_NOTES.md
+++ b/DEV_NOTES.md
@@ -310,3 +310,10 @@ that direct execution (`python tools/export_charts.py`) still works if needed.
 - Risks: aggressive risk rules may freeze trading early; config schema changes require updated YAMLs; thresholds are naive.
 - Migration steps: supply `config/adaptive.yml` and `config/risk.yml` as needed, ensure `--continuous-env` for TD3/TQC, and review new logs under `performance/`.
 - Next actions: refine regime features, add unit tests for risk callbacks, and tune default rule thresholds.
+
+## Developer Notes — 2025-10-21 (Signals collectors & CLI flags)
+- What: added pluggable market collectors (CSV/Parquet and ccxt), signal pipeline builder, `config/signals.yml`, and exposed data-source and advanced TD3/TQC flags.
+- Why: prepare for real-time data and richer feature engineering while enabling algorithm tuning from the CLI.
+- Risks: ccxt availability is optional; misconfigured specs may yield empty features.
+- Migration steps: invoke training with `--data-source csvparquet --signals-spec config/signals.yml`; install `ccxt` for live fetching.
+- Next actions: wire collectors into training loops and expand indicator coverage.

--- a/bot_trade/config/rl_args.py
+++ b/bot_trade/config/rl_args.py
@@ -155,6 +155,22 @@ def parse_args():
     ap.add_argument("--exec-config", type=str, default=None, help="Execution YAML config")
     ap.add_argument("--risk-config", type=str, default=None, help="Risk YAML config")
     ap.add_argument("--gateway", type=str, default="paper", help="Execution gateway (paper|sandbox|ccxt)")
+    ap.add_argument(
+        "--data-source",
+        choices=["csvparquet", "ccxt"],
+        default="csvparquet",
+        help="Market data source",
+    )
+    ap.add_argument("--exchange", type=str, help="ccxt exchange id, e.g., binance")
+    ap.add_argument("--ccxt-symbol", type=str, help="ccxt symbol, e.g., BTC/USDT")
+    ap.add_argument(
+        "--signals-spec",
+        type=str,
+        default="config/signals.yml",
+        help="YAML file describing signal pipeline",
+    )
+    ap.add_argument("--start", type=str, help="Start datetime (UTC) for data fetch")
+    ap.add_argument("--end", type=str, help="End datetime (UTC) for data fetch")
     ap.add_argument("--policy", type=str, default="MlpPolicy")
     ap.add_argument("--device", type=str, default=None)
     ap.add_argument("--n-envs", type=int, default=0)
@@ -274,6 +290,18 @@ def parse_args():
     ap.add_argument("--train-freq", type=int)
     ap.add_argument("--gradient-steps", type=int)
     ap.add_argument("--tau", type=float)
+    ap.add_argument("--policy-delay", type=int, help="TD3 policy delay steps")
+    ap.add_argument("--target-policy-noise", type=float, help="TD3 target policy noise")
+    ap.add_argument("--target-noise-clip", type=float, help="TD3 target noise clip")
+    ap.add_argument("--n-critics", type=int, help="TQC number of critics")
+    ap.add_argument("--n-quantiles", type=int, help="TQC quantiles per critic")
+    ap.add_argument(
+        "--top-quantiles-to-drop-per-net",
+        type=int,
+        help="TQC quantiles dropped per critic",
+    )
+    ap.add_argument("--use-sde", action="store_true", help="Use SDE policies")
+    ap.add_argument("--sde-sample-freq", type=int, help="SDE sample frequency")
     ap.add_argument("--sac-gamma", type=float, help="Override gamma for SAC only")
     ap.add_argument("--warmstart-from-ppo", type=str,
                     help="(Optional) path to PPO .zip to warm-start SAC feature extractor")

--- a/bot_trade/config/rl_builders.py
+++ b/bot_trade/config/rl_builders.py
@@ -548,7 +548,7 @@ def build_tqc(env, args, seed):
     try:
         from sb3_contrib import TQC
     except Exception:
-        print("[ALGO_GUARD] algorithm=TQC unavailable (missing sb3-contrib). Aborting.")
+        print("[ALGO] TQC requires sb3_contrib; try: pip install sb3-contrib==2.2.1")
         raise SystemExit(1)
     pk, pk_keys = _policy_kwargs_from_args(args)
     pk = pk.copy()

--- a/bot_trade/data/collectors/base.py
+++ b/bot_trade/data/collectors/base.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+"""Abstract market data collector interface.
+
+Collectors are simple classes exposing a ``load`` method returning a pandas
+``DataFrame`` with timezone aware UTC index and OHLCV + book fields.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Optional
+
+import pandas as pd
+
+
+class MarketCollector(ABC):
+    """Base class for market data collectors."""
+
+    @abstractmethod
+    def load(
+        self,
+        symbol: str,
+        frame: str,
+        start: Optional[str] = None,
+        end: Optional[str] = None,
+    ) -> pd.DataFrame:
+        """Return a dataframe indexed by UTC timestamps.
+
+        Implementations must return at least the columns ``open``, ``high``,
+        ``low``, ``close`` and ``volume``. Additional optional columns are
+        ``spread_bp``, ``best_bid``, ``best_ask`` and ``depth_top``.
+        """
+        raise NotImplementedError

--- a/bot_trade/data/collectors/ccxt_collector.py
+++ b/bot_trade/data/collectors/ccxt_collector.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+"""Collector fetching data via ccxt if available."""
+
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+
+from .base import MarketCollector
+
+
+class CCXTCollector(MarketCollector):
+    def __init__(self, exchange: str, root: str | Path = "data/cache") -> None:
+        try:
+            import ccxt  # type: ignore
+        except Exception:  # pragma: no cover - optional dependency
+            print("[DATA] ccxt not installed; use CSV/Parquet collector")
+            raise SystemExit(1)
+        self.ccxt = ccxt
+        self.exchange_id = exchange
+        self.root = Path(root)
+
+    def _exchange(self):
+        return getattr(self.ccxt, self.exchange_id)()
+
+    def load(
+        self,
+        symbol: str,
+        frame: str,
+        start: Optional[str] = None,
+        end: Optional[str] = None,
+    ) -> pd.DataFrame:
+        ex = self._exchange()
+        limit = 1000
+        since = int(pd.Timestamp(start or 0, tz="UTC").timestamp() * 1000)
+        ohlcv = ex.fetch_ohlcv(symbol, timeframe=frame, since=since, limit=limit)
+        df = pd.DataFrame(ohlcv, columns=["timestamp", "open", "high", "low", "close", "volume"])
+        df["datetime"] = pd.to_datetime(df["timestamp"], unit="ms", utc=True)
+        df.set_index("datetime", inplace=True)
+        for opt in ["spread_bp", "best_bid", "best_ask", "depth_top"]:
+            df[opt] = float("nan")
+        return df[["open", "high", "low", "close", "volume", "spread_bp", "best_bid", "best_ask", "depth_top"]]

--- a/bot_trade/data/collectors/csv_parquet_collector.py
+++ b/bot_trade/data/collectors/csv_parquet_collector.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+"""Collector reading local CSV/Parquet files.
+
+Files are expected under ``data/ready`` by default. The loader performs light
+validation: timezone normalisation to UTC, column reordering and duplicate
+removal. Missing optional fields are filled with ``NaN``.
+"""
+
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+
+from .base import MarketCollector
+
+
+class CSVParquetCollector(MarketCollector):
+    def __init__(self, root: str | Path = "data/ready") -> None:
+        self.root = Path(root)
+
+    def _read_file(self, path: Path) -> pd.DataFrame:
+        if path.suffix.lower() == ".parquet":
+            df = pd.read_parquet(path)
+        elif path.suffix.lower() == ".csv":
+            df = pd.read_csv(path)
+        else:
+            raise ValueError(f"Unsupported extension: {path.suffix}")
+        return df
+
+    def load(
+        self,
+        symbol: str,
+        frame: str,
+        start: Optional[str] = None,
+        end: Optional[str] = None,
+    ) -> pd.DataFrame:
+        pattern = f"{symbol}-{frame}"
+        files = sorted(self.root.glob(f"**/{pattern}*.parquet"))
+        if not files:
+            files = sorted(self.root.glob(f"**/{pattern}*.csv"))
+        if not files:
+            raise FileNotFoundError(f"no files for {symbol=} {frame=} in {self.root}")
+        dfs: list[pd.DataFrame] = []
+        for fp in files:
+            df = self._read_file(fp)
+            dfs.append(df)
+        df = pd.concat(dfs, ignore_index=True)
+        if "datetime" in df.columns:
+            df["datetime"] = pd.to_datetime(df["datetime"], utc=True, errors="coerce")
+        else:
+            df.index = pd.to_datetime(df.index, utc=True, errors="coerce")
+            df.reset_index(inplace=True)
+            df.rename(columns={"index": "datetime"}, inplace=True)
+        df.sort_values("datetime", inplace=True)
+        df.drop_duplicates(subset=["datetime"], inplace=True)
+        if start:
+            df = df[df["datetime"] >= pd.to_datetime(start, utc=True)]
+        if end:
+            df = df[df["datetime"] <= pd.to_datetime(end, utc=True)]
+        df.set_index("datetime", inplace=True)
+        required = ["open", "high", "low", "close", "volume"]
+        for col in required:
+            if col not in df.columns:
+                df[col] = float("nan")
+        for opt in ["spread_bp", "best_bid", "best_ask", "depth_top"]:
+            if opt not in df.columns:
+                df[opt] = float("nan")
+        return df[required + ["spread_bp", "best_bid", "best_ask", "depth_top"]]

--- a/config/signals.yml
+++ b/config/signals.yml
@@ -1,0 +1,9 @@
+pipeline:
+  - macd: { fast: 12, slow: 26, signal: 9 }
+  - rsi: { period: 14 }
+  - atr: { period: 14 }
+  - realized_vol: { window: 60 }
+  - spread_bp: { window: 10 }
+  - depth_top: { window: 5 }
+post:
+  - zscore: { on: "returns", window: 100 }


### PR DESCRIPTION
## Summary
- add abstract MarketCollector with CSV/Parquet and ccxt implementations
- wire YAML-driven strategy signal pipeline (MACD/RSI/ATR/vol and more)
- expose data-source and advanced TD3/TQC CLI flags; improve TQC dependency message

## Testing
- `python -m py_compile $(git ls-files 'bot_trade/**/*.py' 'bot_trade/*.py')`
- `python -m bot_trade.train_rl --help | head -n 60`
- `python -m bot_trade.tools.gen_synth_data --symbol BTCUSDT --frame 1m --out data_ready`
- `python -m bot_trade.train_rl --algorithm SAC --symbol BTCUSDT --frame 1m --data-source csvparquet --signals-spec config/signals.yml --total-steps 100 --headless --allow-synth --data-dir data_ready --continuous-env`
- `python -m bot_trade.train_rl --algorithm TQC --symbol BTCUSDT --frame 1m --n-critics 5 --n-quantiles 25 --top-quantiles-to-drop-per-net 2 --use-sde --sde-sample-freq 4 --total-steps 2 --headless --allow-synth --data-dir data_ready --continuous-env`


------
https://chatgpt.com/codex/tasks/task_b_68b917f66a88832dafe78adfc0eeae5f