### PR TITLE
feat: add PySimpleGUI control panel

### DIFF
--- a/CHANGE_NOTES.md
+++ b/CHANGE_NOTES.md
@@ -533,3 +533,8 @@ PY`
 - **Rationale**: introduce pluggable market data collectors, YAML-driven signal pipeline, and expose data-source and advanced TD3/TQC CLI flags with clearer TQC dependency guidance.
 - **Risks**: ccxt dependency optional; mis-specified signal configs may lead to empty feature frames.
 - **Test Steps**: `python -m py_compile $(git ls-files 'bot_trade/**/*.py' 'bot_trade/*.py')`; `python -m bot_trade.train_rl --help | head -n 60`
+## 2025-09-04 UI Panel foundation
+- **Files**: `bot_trade/ui/*`, `docs/ui_panel.md`, tests under `tests/ui`.
+- **Rationale**: provide simple control panel with runner, results watcher and command whitelist.
+- **Risks**: polling watcher may miss rapid updates; stop may not handle exotic platforms.
+- **Next steps**: add queue management and richer metrics display.

--- a/DEV_NOTES.md
+++ b/DEV_NOTES.md
@@ -317,3 +317,9 @@ that direct execution (`python tools/export_charts.py`) still works if needed.
 - Risks: ccxt availability is optional; misconfigured specs may yield empty features.
 - Migration steps: invoke training with `--data-source csvparquet --signals-spec config/signals.yml`; install `ccxt` for live fetching.
 - Next actions: wire collectors into training loops and expand indicator coverage.
+## Developer Notes — 2025-09-04 (UI Panel foundation)
+- What: added PySimpleGUI control panel under `bot_trade.ui` with runner, results watcher, whitelist and config.
+- Why: provide desktop orchestration for training and tooling.
+- Risks: limited validation; polling watcher; stop may miss exotic child trees.
+- Migration steps: launch via `python -m bot_trade.ui.panel_gui` and ensure commands conform to whitelist.
+- Next actions: queueing, GPU slot caps and richer metrics display.

--- a/bot_trade/tools/eval_run.py
+++ b/bot_trade/tools/eval_run.py
@@ -22,6 +22,7 @@ from bot_trade.tools import export_charts
 from bot_trade.tools.kb_writer import kb_append
 from bot_trade.eval.gate import gate_metrics
 from bot_trade.tools.force_utf8 import force_utf8
+from bot_trade.tools._headless import ensure_headless_once
 
 
 
@@ -98,14 +99,7 @@ def evaluate_run(symbol: str, frame: str, run_id: str, algo: str = "PPO") -> Dic
 def main(argv: list[str] | None = None) -> int:
     force_utf8()
 
-    def _set_headless() -> None:
-        import matplotlib
-
-        if matplotlib.get_backend().lower() != "agg":
-            matplotlib.use("Agg")
-        print("[HEADLESS] backend=Agg")
-
-    _set_headless()
+    ensure_headless_once("tools.eval_run")
     p = argparse.ArgumentParser(
         description="Synthetic run evaluation",
         epilog=(

--- a/bot_trade/tools/export_charts.py
+++ b/bot_trade/tools/export_charts.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Any, Dict, Tuple, TYPE_CHECKING
 
 from bot_trade.tools.force_utf8 import force_utf8
+from bot_trade.tools._headless import ensure_headless_once
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     import pandas as pd
@@ -302,14 +303,7 @@ def main(argv: list[str] | None = None) -> int:  # pragma: no cover - CLI helper
     import argparse
     from bot_trade.config.rl_paths import get_root
 
-    def _set_headless() -> None:
-        import matplotlib
-
-        if matplotlib.get_backend().lower() != "agg":
-            matplotlib.use("Agg")
-        print("[HEADLESS] backend=Agg")
-
-    _set_headless()
+    ensure_headless_once("tools.export_charts")
 
     ap = argparse.ArgumentParser(
         description="Export charts for a training run",

--- a/bot_trade/tools/monitor_manager.py
+++ b/bot_trade/tools/monitor_manager.py
@@ -9,17 +9,11 @@ from pathlib import Path
 from bot_trade.config.rl_paths import RunPaths, get_root, DEFAULT_REPORTS_DIR
 from bot_trade.tools.latest import latest_run
 from bot_trade.tools import export_charts
+from bot_trade.tools._headless import ensure_headless_once
 
 
 def main(argv: list[str] | None = None) -> int:
-    def _set_headless() -> None:
-        import matplotlib
-
-        if matplotlib.get_backend().lower() != "agg":
-            matplotlib.use("Agg")
-        print("[HEADLESS] backend=Agg")
-
-    _set_headless()
+    ensure_headless_once("tools.monitor_manager")
     ap = argparse.ArgumentParser(
         description="Generate charts for a finished training run",
         epilog=(

--- a/bot_trade/ui/panel_config.yaml
+++ b/bot_trade/ui/panel_config.yaml
@@ -1,9 +1,12 @@
-symbol: BTCUSDT
-frame: 1h
-preset: default
-algorithm: PPO
-max_steps: 1000
-seed: 42
-data_dir: data
-device: auto
-n_envs: 1
+symbols: [BTCUSDT]
+frames: [1m]
+devices: [cpu]
+max_parallel_runs: 1
+defaults:
+  train_rl:
+    total_steps: 100
+    n_envs: 1
+    device: cpu
+    headless: true
+    resume_auto: false
+    allow_synth: false

--- a/bot_trade/ui/panel_gui.py
+++ b/bot_trade/ui/panel_gui.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+"""Simple PySimpleGUI control panel for bot_trade."""
+
+import datetime as dt
+import json
+import queue
+import threading
+from pathlib import Path
+from typing import Dict
+
+import PySimpleGUI as sg
+
+from . import runner, results_watcher, whitelist
+
+CONFIG_PATH = Path(__file__).with_name("panel_config.yaml")
+DEV_NOTES_PATH = Path(__file__).resolve().parents[2] / "docs" / "dev_notes.md"
+LOG_DIR = Path("panel_logs")
+
+
+def load_config() -> Dict:
+    import yaml
+
+    if CONFIG_PATH.exists():
+        with CONFIG_PATH.open("r", encoding="utf-8") as fh:
+            return yaml.safe_load(fh) or {}
+    return {}
+
+
+def save_config(cfg: Dict) -> None:
+    import yaml
+    with CONFIG_PATH.open("w", encoding="utf-8") as fh:
+        yaml.safe_dump(cfg, fh)
+
+
+def latest_dev_note() -> str:
+    if not DEV_NOTES_PATH.exists():
+        return ""
+    lines = DEV_NOTES_PATH.read_text(encoding="utf-8").splitlines()
+    return "\n".join(lines[-10:])
+
+
+class Panel:
+    def __init__(self) -> None:
+        self.cfg = load_config()
+        self.queue: queue.Queue = queue.Queue()
+        self.handles: Dict[str, runner.ProcessHandle] = {}
+        self.watchers: Dict[str, results_watcher.ResultsWatcher] = {}
+        sg.theme("SystemDefault")
+        self.window = sg.Window(
+            "bot_trade Panel",
+            self._layout(),
+            finalize=True,
+            resizable=True,
+        )
+        self.window["notes"].update(latest_dev_note())
+
+    # ------------------------------------------------------------------
+    def _layout(self):
+        cfg = self.cfg.get("defaults", {}).get("train_rl", {})
+        config_tab = [
+            [sg.Text("Symbol"), sg.Input(cfg.get("symbol", "BTCUSDT"), key="symbol")],
+            [sg.Text("Frame"), sg.Input(cfg.get("frame", "1m"), key="frame")],
+            [sg.Text("Steps"), sg.Input(str(cfg.get("total_steps", 1000)), key="steps")],
+            [sg.Text("n-envs"), sg.Input(str(cfg.get("n_envs", 1)), key="n_envs")],
+            [sg.Text("Device"), sg.Input(cfg.get("device", "cpu"), key="device")],
+            [sg.Checkbox("Headless", key="headless", default=cfg.get("headless", True))],
+            [sg.Checkbox("Allow synth", key="allow_synth", default=cfg.get("allow_synth", False))],
+            [sg.Button("Start"), sg.Button("Stop"), sg.Button("Exit")],
+            [sg.Multiline("", size=(60, 10), key="log")],
+            [sg.Text("Developer Notes")],
+            [sg.Multiline("", size=(60, 10), key="notes", disabled=True)],
+        ]
+        runs_tab = [[sg.Table(values=[], headings=["Run", "Status"], key="runs", auto_size_columns=True, expand_x=True, expand_y=True)]]
+        tools_tab = [[sg.Text("Tools placeholder")]]
+        live_tab = [[sg.Text("Live monitor placeholder")]]
+        layout = [
+            [
+                sg.TabGroup(
+                    [
+                        [
+                            sg.Tab("Config", config_tab),
+                            sg.Tab("Runs", runs_tab),
+                            sg.Tab("Tools", tools_tab),
+                            sg.Tab("Live", live_tab),
+                        ]
+                    ],
+                    expand_x=True,
+                    expand_y=True,
+                )
+            ]
+        ]
+        return layout
+
+    # ------------------------------------------------------------------
+    def run(self) -> None:
+        while True:
+            event, values = self.window.read(timeout=200)
+            if event in (sg.WIN_CLOSED, "Exit"):
+                self._shutdown()
+                break
+            if event == "Start":
+                self._start_run(values)
+            if event == "Stop":
+                self._stop_selected()
+            self._drain_queue()
+
+    def _start_run(self, values):
+        params = {
+            "symbol": values["symbol"],
+            "frame": values["frame"],
+            "total_steps": int(values["steps"]),
+            "n_envs": int(values["n_envs"]),
+            "device": values["device"],
+            "headless": values["headless"],
+            "allow_synth": values["allow_synth"],
+        }
+        try:
+            cmd = whitelist.build_command("train_rl", params)
+        except whitelist.ValidationError as exc:
+            sg.popup(str(exc))
+            return
+        LOG_DIR.mkdir(exist_ok=True)
+        run_id = dt.datetime.utcnow().strftime("%Y%m%d%H%M%S")
+        tee = LOG_DIR / f"run_{run_id}.log"
+        handle = runner.start_command(cmd, tee_path=tee, metadata=params)
+        self.handles[run_id] = handle
+        watcher = results_watcher.ResultsWatcher(Path("results")/params["symbol"]/params["frame"]/"dummy", tee, self.queue)
+        watcher.start()
+        self.watchers[run_id] = watcher
+        self._refresh_runs()
+
+    def _stop_selected(self):
+        table = self.window["runs"]
+        sel = table.SelectedRows
+        if not sel:
+            return
+        run_id = list(self.handles.keys())[sel[0]]
+        handle = self.handles.get(run_id)
+        if handle:
+            runner.stop_process_tree(handle)
+        watcher = self.watchers.get(run_id)
+        if watcher:
+            watcher.stop()
+        self._refresh_runs()
+
+    def _drain_queue(self):
+        log_elem = self.window["log"]
+        try:
+            while True:
+                item = self.queue.get_nowait()
+                if isinstance(item, dict):
+                    log_elem.update(str(item) + "\n", append=True)
+        except queue.Empty:
+            pass
+
+    def _refresh_runs(self):
+        data = []
+        for rid, handle in self.handles.items():
+            status = "running" if handle.process.poll() is None else "stopped"
+            data.append([rid, status])
+        self.window["runs"].update(values=data)
+
+    def _shutdown(self):
+        cfg = {
+            "defaults": {
+                "train_rl": {
+                    "symbol": self.window["symbol"].get(),
+                    "frame": self.window["frame"].get(),
+                    "total_steps": int(self.window["steps"].get()),
+                    "n_envs": int(self.window["n_envs"].get()),
+                    "device": self.window["device"].get(),
+                    "headless": self.window["headless"].get(),
+                    "allow_synth": self.window["allow_synth"].get(),
+                }
+            }
+        }
+        save_config(cfg)
+        for watcher in self.watchers.values():
+            watcher.stop()
+        for handle in self.handles.values():
+            runner.stop_process_tree(handle)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    Panel().run()

--- a/bot_trade/ui/results_watcher.py
+++ b/bot_trade/ui/results_watcher.py
@@ -1,74 +1,90 @@
+from __future__ import annotations
+
+"""Watch run artifacts and emit structured events."""
+
+import csv
 import json
 import os
 import threading
-from dataclasses import dataclass
+import time
+from pathlib import Path
 from queue import Queue
-from typing import Optional, Dict, Any
-
-import pandas as pd
-from watchdog.events import FileSystemEventHandler
-from watchdog.observers import Observer
-
-
-@dataclass
-class WatchEvent:
-    kind: str
-    path: str
-    data: Dict[str, Any]
-
-
-class _Handler(FileSystemEventHandler):
-    def __init__(self, queue: Queue):
-        self.queue = queue
-
-    def on_modified(self, event):  # type: ignore[override]
-        if event.is_directory:
-            return
-        path = event.src_path
-        fname = os.path.basename(path)
-        if fname == "metrics.csv":
-            try:
-                df = pd.read_csv(path)
-                last = df.tail(1).to_dict("records")[0] if not df.empty else {}
-                self.queue.put(WatchEvent("metrics", path, last))
-            except Exception as exc:  # pragma: no cover - logged via queue
-                self.queue.put(WatchEvent("metrics_error", path, {"error": str(exc)}))
-        elif fname == "summary.json":
-            try:
-                with open(path, "r", encoding="utf-8") as fh:
-                    data = json.load(fh)
-                self.queue.put(WatchEvent("summary", path, data))
-            except Exception as exc:  # pragma: no cover
-                self.queue.put(WatchEvent("summary_error", path, {"error": str(exc)}))
-        elif fname == "risk_flags.jsonl":
-            try:
-                with open(path, "r", encoding="utf-8") as fh:
-                    lines = fh.readlines()[-5:]
-                self.queue.put(WatchEvent("risk_flags", path, {"lines": lines}))
-            except Exception as exc:  # pragma: no cover
-                self.queue.put(WatchEvent("risk_flags_error", path, {"error": str(exc)}))
+from typing import Dict, Iterable
 
 
 class ResultsWatcher:
-    """Watch results directory for updated artefacts."""
-
-    def __init__(self, run_dir: str, queue: Optional[Queue] = None) -> None:
+    def __init__(self, run_dir: Path, log_path: Path, out_queue: Queue, poll_sec: float = 0.5) -> None:
         self.run_dir = run_dir
-        self.queue = queue or Queue()
-        self.observer: Optional[Observer] = None
-        self.handler = _Handler(self.queue)
+        self.log_path = log_path
+        self.queue = out_queue
+        self.poll_sec = poll_sec
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._metrics_pos = 0
+        self._log_pos = 0
+        self._summary_mtime = 0.0
 
     def start(self) -> None:
-        self.observer = Observer()
-        self.observer.schedule(self.handler, self.run_dir, recursive=False)
-        self.observer.start()
+        self._thread = threading.Thread(target=self._loop, daemon=True)
+        self._thread.start()
 
     def stop(self) -> None:
-        if self.observer:
-            self.observer.stop()
-            self.observer.join(timeout=2)
-            self.observer = None
+        self._stop.set()
+        if self._thread:
+            self._thread.join(timeout=1)
 
-    def join(self) -> None:
-        if self.observer:
-            self.observer.join()
+    # ------------------------------------------------------------------
+    def _loop(self) -> None:
+        metrics_path = self.run_dir / "performance" / "metrics.csv"
+        summary_path = self.run_dir / "performance" / "summary.json"
+        while not self._stop.is_set():
+            try:
+                if metrics_path.exists():
+                    self._check_metrics(metrics_path)
+                if summary_path.exists():
+                    self._check_summary(summary_path)
+                if self.log_path.exists():
+                    self._check_log(self.log_path)
+            except Exception:
+                pass
+            time.sleep(self.poll_sec)
+
+    def _check_metrics(self, path: Path) -> None:
+        size = path.stat().st_size
+        if size <= self._metrics_pos:
+            return
+        with path.open("r", encoding="utf-8") as fh:
+            fh.seek(self._metrics_pos)
+            reader = csv.DictReader(fh)
+            for row in reader:
+                self.queue.put({"event": "metric", "data": row})
+            self._metrics_pos = fh.tell()
+
+    def _check_summary(self, path: Path) -> None:
+        mtime = path.stat().st_mtime
+        if mtime <= self._summary_mtime:
+            return
+        self._summary_mtime = mtime
+        try:
+            with path.open("r", encoding="utf-8") as fh:
+                data = json.load(fh)
+            self.queue.put({"event": "summary", "data": data})
+        except Exception:
+            pass
+
+    def _check_log(self, path: Path) -> None:
+        size = path.stat().st_size
+        if size <= self._log_pos:
+            return
+        with path.open("r", encoding="utf-8") as fh:
+            fh.seek(self._log_pos)
+            for line in fh:
+                line = line.strip()
+                if line.startswith("[CHARTS] "):
+                    self.queue.put({"event": "charts", "line": line})
+                elif line.startswith("[POSTRUN] "):
+                    self.queue.put({"event": "postrun", "line": line})
+            self._log_pos = fh.tell()
+
+
+__all__ = ["ResultsWatcher"]

--- a/bot_trade/ui/whitelist.py
+++ b/bot_trade/ui/whitelist.py
@@ -1,25 +1,160 @@
 from __future__ import annotations
 
-import yaml
-from pathlib import Path
-from typing import Dict, List
+"""Command template whitelist for the control panel."""
 
-WHITELIST_PATH = Path(__file__).with_name("whitelist.yaml")
+import re
+from typing import Callable, Dict, List
 
-
-def load_whitelist(path: Path = WHITELIST_PATH) -> Dict[str, List[str]]:
-    with open(path, "r", encoding="utf-8") as fh:
-        data = yaml.safe_load(fh) or {}
-    return {str(k): list(v) for k, v in data.items()}
+SYMBOL_RE = re.compile(r"^[A-Z0-9]+(USDT|USD|USDC)$")
+FRAME_SET = {"1s","1m","3m","5m","15m","30m","1h","2h","4h","8h","12h","1d"}
+DEVICE_SET = {"cpu","cuda:0","cuda:1","auto"}
+RUN_ID_RE = re.compile(r"^(latest|[0-9a-fA-F-]{4,36})$")
 
 
-def build_command(name: str, params: Dict[str, str], whitelist: Dict[str, List[str]] | None = None) -> List[str]:
-    wl = whitelist or load_whitelist()
-    if name not in wl:
-        raise ValueError(f"command '{name}' not in whitelist")
-    template = wl[name]
+class ValidationError(ValueError):
+    """Raised when parameters do not match the whitelist."""
+
+
+def _pos_int(val: object, name: str) -> int:
     try:
-        return [part.format(**params) for part in template]
-    except KeyError as exc:  # pragma: no cover - user error
-        missing = exc.args[0]
-        raise ValueError(f"missing placeholder '{missing}' for command '{name}'") from exc
+        iv = int(val)
+    except Exception as exc:  # noqa: BLE001
+        raise ValidationError(f"{name} must be int") from exc
+    if iv <= 0:
+        raise ValidationError(f"{name} must be >0")
+    return iv
+
+
+def _bool_flag(params: Dict[str, object], name: str) -> List[str]:
+    return [f"--{name}"] if params.get(name) else []
+
+# ---------------------------------------------------------------------------
+# Templates
+# ---------------------------------------------------------------------------
+
+def _train_rl(params: Dict[str, object]) -> List[str]:
+    allowed = {
+        "symbol","frame","total_steps","n_envs","device","headless","resume_auto",
+        "allow_synth","data_dir","algorithm"
+    }
+    unknown = set(params) - allowed
+    if unknown:
+        raise ValidationError(f"unknown flags: {sorted(unknown)}")
+    symbol = params["symbol"]
+    frame = params["frame"]
+    if not SYMBOL_RE.match(str(symbol)):
+        raise ValidationError("invalid symbol")
+    if frame not in FRAME_SET:
+        raise ValidationError("invalid frame")
+    device = params.get("device","cpu")
+    if device not in DEVICE_SET:
+        raise ValidationError("invalid device")
+    _pos_int(params.get("total_steps",1),"total_steps")
+    _pos_int(params.get("n_envs",1),"n_envs")
+    cmd = [
+        "python","-m","bot_trade.train_rl",
+        "--symbol",str(symbol),"--frame",str(frame),
+        "--total-steps",str(params.get("total_steps",1)),
+        "--n-envs",str(params.get("n_envs",1)),
+        "--device",device,
+    ]
+    cmd += _bool_flag(params,"headless")
+    cmd += _bool_flag(params,"resume_auto")
+    cmd += _bool_flag(params,"allow_synth")
+    if "data_dir" in params:
+        cmd += ["--data-dir",str(params["data_dir"])]
+    if "algorithm" in params:
+        cmd += ["--algorithm",str(params["algorithm"])]
+    return cmd
+
+
+def _eval_run(params: Dict[str, object]) -> List[str]:
+    allowed = {"symbol","frame","run_id","tearsheet"}
+    unknown = set(params) - allowed
+    if unknown:
+        raise ValidationError(f"unknown flags: {sorted(unknown)}")
+    symbol = params["symbol"]
+    frame = params["frame"]
+    run_id = params["run_id"]
+    if not SYMBOL_RE.match(str(symbol)) or frame not in FRAME_SET:
+        raise ValidationError("invalid symbol/frame")
+    if not RUN_ID_RE.match(str(run_id)):
+        raise ValidationError("invalid run_id")
+    cmd = [
+        "python","-m","bot_trade.tools.eval_run",
+        "--symbol",symbol,"--frame",frame,"--run-id",run_id,
+    ]
+    cmd += _bool_flag(params,"tearsheet")
+    return cmd
+
+
+def _monitor_manager(params: Dict[str, object]) -> List[str]:
+    allowed = {"symbol","frame","run_id","headless"}
+    unknown = set(params) - allowed
+    if unknown:
+        raise ValidationError(f"unknown flags: {sorted(unknown)}")
+    symbol = params["symbol"]
+    frame = params["frame"]
+    run_id = params["run_id"]
+    if not SYMBOL_RE.match(str(symbol)) or frame not in FRAME_SET:
+        raise ValidationError("invalid symbol/frame")
+    if not RUN_ID_RE.match(str(run_id)):
+        raise ValidationError("invalid run_id")
+    cmd = [
+        "python","-m","bot_trade.tools.monitor_manager",
+        "--symbol",symbol,"--frame",frame,"--run-id",run_id,
+    ]
+    cmd += _bool_flag(params,"headless")
+    return cmd
+
+
+def _gen_synth_data(params: Dict[str, object]) -> List[str]:
+    allowed = {"symbol","frame","days","out"}
+    unknown = set(params) - allowed
+    if unknown:
+        raise ValidationError(f"unknown flags: {sorted(unknown)}")
+    symbol = params["symbol"]
+    frame = params["frame"]
+    days = params["days"]
+    out = params["out"]
+    if not SYMBOL_RE.match(str(symbol)) or frame not in FRAME_SET:
+        raise ValidationError("invalid symbol/frame")
+    _pos_int(days,"days")
+    cmd = [
+        "python","-m","bot_trade.tools.gen_synth_data",
+        "--symbol",symbol,"--frame",frame,"--days",str(days),"--out",str(out),
+    ]
+    return cmd
+
+
+def _paths_doctor(params: Dict[str, object]) -> List[str]:
+    allowed = {"symbol","frame","strict"}
+    unknown = set(params) - allowed
+    if unknown:
+        raise ValidationError(f"unknown flags: {sorted(unknown)}")
+    symbol = params["symbol"]
+    frame = params["frame"]
+    if not SYMBOL_RE.match(str(symbol)) or frame not in FRAME_SET:
+        raise ValidationError("invalid symbol/frame")
+    cmd = ["python","-m","bot_trade.tools.paths_doctor","--symbol",symbol,"--frame",frame]
+    if params.get("strict"):
+        cmd.append("--strict")
+    return cmd
+
+
+TEMPLATES: Dict[str, Callable[[Dict[str, object]], List[str]]] = {
+    "train_rl": _train_rl,
+    "eval_run": _eval_run,
+    "monitor_manager": _monitor_manager,
+    "gen_synth_data": _gen_synth_data,
+    "paths_doctor": _paths_doctor,
+}
+
+
+def build_command(name: str, params: Dict[str, object]) -> List[str]:
+    if name not in TEMPLATES:
+        raise ValidationError("unknown command")
+    return TEMPLATES[name](params)
+
+
+__all__ = ["build_command", "ValidationError", "TEMPLATES"]

--- a/docs/dev_notes.md
+++ b/docs/dev_notes.md
@@ -45,3 +45,8 @@
 - WHY: improve traceability and reliability for multi-run orchestration.
 - RISKS: stop handling may miss zombie children on exotic platforms.
 - NEXT: surface metrics charts and sandbox key validation.
+[2025-09-04 05:16:28] Developer Notes — Panel v1 Controls
+- WHAT: added PySimpleGUI panel with runner, results watcher, whitelist and defaults.
+- WHY: enable desktop orchestration with safe process handling.
+- RISKS: limited log handling; watcher polls filesystem.
+- NEXT: surface charts and queue management.

--- a/docs/ui_panel.md
+++ b/docs/ui_panel.md
@@ -1,36 +1,18 @@
-# UI Panel
+# UI Control Panel
 
-Minimal PySimpleGUI control panel for orchestrating training and tooling.
+Minimal PySimpleGUI interface to manage training runs and tools.
 
-## Install
+## Usage
 
-```bash
-pip install -r requirements.txt  # includes PySimpleGUI, psutil, watchdog, pyyaml
+```
+python -m bot_trade.ui.panel_gui
 ```
 
-## Launch
+The panel validates commands against a strict whitelist and spawns them
+via `ui.runner`. Results are tailed by `ui.results_watcher`.
 
-```bash
-python -m bot_trade.ui.panel
-```
+## Safety Notes
 
-## Tabs
-
-- **Run Train** – set symbol/frame/algorithm and launch trainings. Each run streams logs and can be stopped independently.
-- **Eval & WFA** – run evaluation helpers on completed results.
-- **Live (Paper/Sandbox)** – guarded entry points for paper or sandbox live modes.
-- **Data & Tools** – whitelisted maintenance scripts such as synthetic data generation.
-- **Logs & Errors** – switch between run logs and copy the last 200 lines.
-- **Config** – environment key status and latest developer-note entry.
-
-State is saved to `bot_trade/ui/panel_config.yaml` on exit so selections persist.
-
-## Sandbox notes
-
-Sandbox live trading is disabled unless testnet API keys are present and the consent box is checked.
-
-## Troubleshooting
-
-- Missing results artefacts → run a training first.
-- "⚠️" on API keys → export the required environment variables.
-- GPU not detected → panel defaults to CPU; select `cpu` explicitly if needed.
+- Only predefined commands may run.
+- Process trees are terminated on Stop.
+- Logs are written UTF-8 to the `tee` files.

--- a/tests/ui/test_results_watcher.py
+++ b/tests/ui/test_results_watcher.py
@@ -1,4 +1,6 @@
+import json
 import time
+from pathlib import Path
 from queue import Queue
 
 from bot_trade.ui.results_watcher import ResultsWatcher
@@ -6,12 +8,22 @@ from bot_trade.ui.results_watcher import ResultsWatcher
 
 def test_results_watcher_detects_metrics(tmp_path):
     run_dir = tmp_path
-    q = Queue()
-    watcher = ResultsWatcher(str(run_dir), q)
+    perf = run_dir / "performance"
+    perf.mkdir()
+    metrics = perf / "metrics.csv"
+    metrics.write_text("a,b\n", encoding="utf-8")
+    summary = perf / "summary.json"
+    log = tmp_path / "run.log"
+    q: Queue = Queue()
+    watcher = ResultsWatcher(run_dir, log, q, poll_sec=0.1)
     watcher.start()
-    metrics = run_dir / "metrics.csv"
-    metrics.write_text("a,b\n1,2\n")
+    metrics.write_text("a,b\n1,2\n", encoding="utf-8")
+    summary.write_text(json.dumps({"x":1}), encoding="utf-8")
+    with log.open("w", encoding="utf-8") as fh:
+        fh.write("[CHARTS] dir=/tmp images=5\n")
+        fh.write("[POSTRUN] ok\n")
     time.sleep(0.5)
-    event = q.get(timeout=2)
-    assert event.kind == "metrics"
     watcher.stop()
+    events = [q.get_nowait() for _ in range(q.qsize())]
+    types = {e["event"] for e in events}
+    assert {"metric","summary","charts","postrun"} <= types

--- a/tests/ui/test_runner.py
+++ b/tests/ui/test_runner.py
@@ -1,22 +1,20 @@
+import sys
 import time
 from pathlib import Path
-from queue import Queue
 
 from bot_trade.ui import runner
 
 
 def test_runner_start_stop(tmp_path):
-    log_queue = Queue()
-    log_path = tmp_path / "echo.log"
-    pid = runner.start_command(
-        ["python", "-c", "import time,sys; print('hello'); sys.stdout.flush(); time.sleep(1)"],
-        run_id="echo",
-        tee_path=str(log_path),
-        log_queue=log_queue,
+    log = tmp_path / "tee.log"
+    script = (
+        "import subprocess,sys,time;"
+        "subprocess.Popen([sys.executable,'-c','import time; time.sleep(30)']);"
+        "print('hello');sys.stdout.flush();time.sleep(30)"
     )
-    time.sleep(0.2)
-    assert log_path.exists()
-    line = log_queue.get(timeout=2)
-    assert "hello" in line["line"]
-    res = runner.stop_process_tree(pid)
-    assert res["stopped"]
+    handle = runner.start_command([sys.executable, "-c", script], tee_path=log, metadata={})
+    assert handle.pid > 0
+    time.sleep(1)
+    rc = runner.stop_process_tree(handle, grace_sec=1)
+    assert handle.process.poll() is not None
+    assert log.read_text(encoding="utf-8").strip() != ""

--- a/tests/ui/test_whitelist.py
+++ b/tests/ui/test_whitelist.py
@@ -1,15 +1,15 @@
 import pytest
-
-from bot_trade.ui.whitelist import build_command, load_whitelist
+from bot_trade.ui import whitelist
 
 
 def test_reject_non_whitelisted():
-    wl = load_whitelist()
-    with pytest.raises(ValueError):
-        build_command("nonexistent", {}, wl)
+    with pytest.raises(whitelist.ValidationError):
+        whitelist.build_command("train_rl", {"symbol":"BTCUSDT","frame":"1m","total_steps":1,"n_envs":1,"device":"cpu","foo":1})
 
 
-def test_template_expansion():
-    wl = {"demo": ["echo", "{symbol}", "{frame}"]}
-    cmd = build_command("demo", {"symbol": "BTC", "frame": "1h"}, wl)
-    assert cmd == ["echo", "BTC", "1h"]
+def test_accept_training_and_eval():
+    cmd = whitelist.build_command("train_rl", {
+        "symbol":"BTCUSDT","frame":"1m","total_steps":1,"n_envs":1,"device":"cpu"})
+    assert cmd[:3] == ["python","-m","bot_trade.train_rl"]
+    cmd2 = whitelist.build_command("eval_run", {"symbol":"BTCUSDT","frame":"1m","run_id":"latest"})
+    assert cmd2[:3] == ["python","-m","bot_trade.tools.eval_run"]


### PR DESCRIPTION
## Summary
- add runner, results watcher and whitelist for controlled subprocess execution
- document and expose simple PySimpleGUI panel
- standardize headless setup via ensure_headless_once

## Testing
- `python -m py_compile $(git ls-files 'bot_trade/**/*.py' 'bot_trade/*.py')`
- `PYTHONPATH=. pytest tests/ui/test_runner.py::test_runner_start_stop -q`
- `PYTHONPATH=. pytest tests/ui/test_whitelist.py::test_reject_non_whitelisted -q`
- `PYTHONPATH=. pytest tests/ui/test_results_watcher.py::test_results_watcher_detects_metrics -q`


------
https://chatgpt.com/codex/tasks/task_b_68b91fd540cc832d99ef1c5c4f36473c